### PR TITLE
fix: SQLite crash on startup when is_active column missing

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -284,7 +284,6 @@ const schema = `
 
   CREATE INDEX IF NOT EXISTS idx_history_account_ts ON failover_history (account_id, timestamp DESC);
   CREATE INDEX IF NOT EXISTS idx_rules_account ON autopilot_rules (account_id);
-  CREATE INDEX IF NOT EXISTS idx_rules_active_id ON autopilot_rules (is_active, id);
 `
 
 // Execute schema creation
@@ -349,6 +348,13 @@ try {
             await db.run(`ALTER TABLE autopilot_rules ADD COLUMN last_notification BIGINT`)
             fastify.log.info({ category: 'Database' }, 'Migrated: Added last_notification column to autopilot_rules')
         }
+        const hasIsActive = tableInfo.some(col => col.name === 'is_active')
+        if (!hasIsActive) {
+            await db.run(`ALTER TABLE autopilot_rules ADD COLUMN is_active INTEGER DEFAULT 1`)
+            fastify.log.info({ category: 'Database' }, 'Migrated: Added is_active column to autopilot_rules')
+        }
+        // Create index on is_active after ensuring the column exists
+        await db.exec(`CREATE INDEX IF NOT EXISTS idx_rules_active_id ON autopilot_rules (is_active, id)`)
     }
 } catch (migrationErr) {
     fastify.log.warn({ category: 'Database' }, `Migration warning: ${migrationErr.message}`)


### PR DESCRIPTION
## Summary

- Existing SQLite databases crash on startup with `SqliteError: no such column: is_active`
- The `idx_rules_active_id` index (on `is_active, id`) was created inside the schema exec block, which ran **before** the migration block that adds missing columns
- `is_active` was also never included in the SQLite migration list (unlike `is_automatic`, `addon_list`, etc.)

## Fix

- Remove `idx_rules_active_id` from the schema block
- Add `is_active` to the SQLite migration block (follows existing pattern)
- Create `idx_rules_active_id` after the column is guaranteed to exist

## Test plan

- [ ] Start with an existing SQLite database that was created before `is_active` was added — server should start without error
- [ ] Start with a fresh SQLite database — tables, migrations, and indexes all created correctly
- [ ] Verify `is_active` column and `idx_rules_active_id` index are present after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)