### PR TITLE
chore: add .github/ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,55 @@
+name: 🐛 Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+        *To prevent duplicates be sure to search for existing issues first.*
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version are you using? The version number can be seen at the bottom of your AIOManager page.
+      placeholder: v1.8.5+build.2
+    validations:
+      required: true
+  - type: dropdown
+    id: instance
+    attributes:
+      label: Instance
+      description: What instance are using?
+      multiple: false
+      options:
+        - Selfhosted instance
+        - ElfHosted
+        - Midnight (ForTheWeebs)
+        - Yeb (ForTheWeak)
+        - Kuu
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: What browser are you using?
+      placeholder: Chrome, Firefox, Safari, Edge, Opera, ...
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Give as much detail as possible. The better the description, the higher the chance we can fix the issue!
+      placeholder: Be sure to include screenshots and links, if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      placeholder: Feel free to leave empty if not applicable.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discord Community Support
+    url: https://discord.gg/cTyvsFEKCE
+    about: Please join the "aiomanager" channel to ask and answer questions.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,18 @@
+name: 🚀 Feature request
+description: Request a new feature.
+title: "[Feature request]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature!
+        *To prevent duplicates be sure to search for existing feature requests first.*
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature description
+      description: Give as much detail as possible. The better the description, the higher the chance we can implement your request!
+      placeholder: My detailed feature suggestion...
+    validations:
+      required: true


### PR DESCRIPTION
Adds [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) to the repository and disables blank issues.
This forces users to fill in certain fields when creating a new issue.

Feel free to adjust to your needs!


## Visuals

This is what a user will see when clicking "New issue". (Except for the security vulnerability report, which you can set up [here](https://github.com/Sonicx161/AIOManager/security/policy))
<img width="810" height="314" alt="image" src="https://github.com/user-attachments/assets/bd0e8851-2109-4126-91bf-8399080c81ac" />

Bug report form:
<img width="799" height="767" alt="image" src="https://github.com/user-attachments/assets/b8ad044d-3d79-43e5-8840-fbc672cb8910" />

Feature request form:
<img width="806" height="599" alt="image" src="https://github.com/user-attachments/assets/45352f0a-402c-485c-93f9-fbc032827053" />
