### PR TITLE
fix(failover): keep custom health checks through a re-login, and run them in Simulate

### DIFF
--- a/server/autopilot/engine.js
+++ b/server/autopilot/engine.js
@@ -35,6 +35,7 @@ export function createAutopilotEngine(fastify, reconciler = null) {
     const AUTOPILOT_CYCLE_BUDGET_MS = Math.max(5000, parseInt(process.env.AUTOPILOT_CYCLE_BUDGET_MS || '120000', 10) || 120000)
     const HEALTH_CACHE_TTL_MS = Math.max(10000, parseInt(process.env.AUTOPILOT_HEALTH_CACHE_TTL_MS || '30000', 10) || 30000)
     const RULE_RECHECK_MS = Math.max(10000, parseInt(process.env.AUTOPILOT_RULE_RECHECK_MS || '30000', 10) || 30000)
+    const HEARTBEAT_PERSIST_MS = Math.max(30000, parseInt(process.env.AUTOPILOT_HEARTBEAT_PERSIST_MS || '300000', 10) || 300000)
     const ruleRuntimeState = new Map()
 
     const RULE_CACHE_MAX_BYTES = Math.max(0, parseInt(process.env.AUTOPILOT_RULE_CACHE_MAX_BYTES || String(256 * 1024 * 1024), 10) || 0)
@@ -1106,7 +1107,10 @@ export function createAutopilotEngine(fastify, reconciler = null) {
             activeUrl: needsSync && !syncSucceeded ? decryptedActiveUrl : targetActiveUrl
         })
 
-        if (!needsColdUpdate && !needsStatsUpdate) {
+        const lastPersistedCheck = Number(rule.last_check) || 0
+        const heartbeatDue = now - lastPersistedCheck >= HEARTBEAT_PERSIST_MS
+
+        if (!needsColdUpdate && !needsStatsUpdate && !heartbeatDue) {
             return null
         }
 

--- a/server/routes/autopilot.js
+++ b/server/routes/autopilot.js
@@ -292,6 +292,7 @@ export function registerAutopilotRoutes(fastify, autopilotEngine) {
             isActive: rule.is_active === 1,
             isAutomatic: rule.is_automatic === 1,
             lastCheck: runtime?.lastCheck ?? rule.last_check,
+            messageTemplate: rule.message_template || null,
             stabilization: runtime?.stabilization ?? parseStabilization(rule.stabilization),
             customCheckUrls: Array.isArray(customCheckUrls) ? customCheckUrls : []
         }
@@ -500,7 +501,7 @@ export function registerAutopilotRoutes(fastify, autopilotEngine) {
                 SELECT r.id, r.priority_chain, r.active_url, r.webhook_url, r.is_active, r.is_automatic,
                        COALESCE(s.last_check, r.last_check) AS last_check,
                        COALESCE(s.stabilization, r.stabilization) AS stabilization,
-                       r.name, r.cooldown_ms, r.custom_check_urls
+                       r.name, r.cooldown_ms, r.custom_check_urls, r.message_template
                 FROM autopilot_rules r
                 LEFT JOIN autopilot_rule_stats s ON s.rule_id = r.id
                 WHERE r.account_id = $1
@@ -711,7 +712,7 @@ export function registerAutopilotRoutes(fastify, autopilotEngine) {
             `SELECT r.id, r.account_id, r.priority_chain, r.active_url, r.webhook_url, r.is_active, r.is_automatic,
                     COALESCE(s.last_check, r.last_check) AS last_check,
                     COALESCE(s.stabilization, r.stabilization) AS stabilization,
-                    r.name, r.cooldown_ms, r.custom_check_urls
+                    r.name, r.cooldown_ms, r.custom_check_urls, r.message_template
              FROM autopilot_rules r
              LEFT JOIN autopilot_rule_stats s ON s.rule_id = r.id
              WHERE r.owner_sync_user = $1 AND r.account_id IN (${placeholders})`,

--- a/src/components/accounts/FailoverManager.tsx
+++ b/src/components/accounts/FailoverManager.tsx
@@ -592,9 +592,28 @@ export function FailoverManager({
         })
     }
 
-    const handleSimulateRule = async (ruleId: string, chain: string[]) => {
+    const runCustomCheck = async (url: string): Promise<{ ok: boolean; error?: string }> => {
+        try {
+            const { useSyncStore } = await import('@/store/syncStore')
+            const { serverUrl } = useSyncStore.getState()
+            const baseUrl = serverUrl || ''
+            const result = await apiFetch<{ ok?: boolean; status?: number; error?: string }>('/autopilot/test-url', {
+                method: 'POST',
+                baseUrl: baseUrl.startsWith('http') ? baseUrl : undefined,
+                body: { url },
+            })
+            if (!result.ok) return { ok: false, error: result.error || `Server error (${result.status})` }
+            return { ok: Boolean(result.data?.ok), error: result.data?.error }
+        } catch {
+            return { ok: false, error: 'Request failed' }
+        }
+    }
+
+    const handleSimulateRule = async (ruleId: string, chain: string[], customCheckUrls?: CustomCheckEntry[]) => {
         setSimulatingRuleId(ruleId)
         setSimulationResults({})
+
+        const checks = normalizeCustomChecks(customCheckUrls).filter(c => c.url.trim())
 
         for (const url of chain) {
             setSimulationResults(prev => ({
@@ -604,9 +623,29 @@ export function FailoverManager({
 
             try {
                 const health = await checkAddonHealth(url)
+                let healthy = health.isOnline
+                let error = health.error
+
+                // Mirrors engine.js: an unscoped check applies to every addon in the chain.
+                if (healthy && checks.length > 0) {
+                    const normUrl = normalizeAddonUrl(url).toLowerCase()
+                    const applicable = checks.filter(c =>
+                        c.appliesTo.length === 0 ||
+                        c.appliesTo.some(au => normalizeAddonUrl(au).toLowerCase() === normUrl)
+                    )
+                    for (const checkUrl of [...new Set(applicable.map(c => c.url))]) {
+                        const res = await runCustomCheck(checkUrl)
+                        if (!res.ok) {
+                            healthy = false
+                            error = res.error ? `Health check failed: ${res.error}` : 'Health check failed'
+                            break
+                        }
+                    }
+                }
+
                 setSimulationResults(prev => ({
                     ...prev,
-                    [url]: { healthy: health.isOnline, checking: false, error: health.error }
+                    [url]: { healthy, checking: false, error }
                 }))
             } catch (err) {
                 setSimulationResults(prev => ({
@@ -1405,7 +1444,7 @@ export function FailoverManager({
                                                         </Button>
                                                     </DropdownMenuTrigger>
                                                     <DropdownMenuContent align="end" className="w-48">
-                                                        <DropdownMenuItem className="gap-2" onClick={() => handleSimulateRule(rule.id, rule.priorityChain)}>
+                                                        <DropdownMenuItem className="gap-2" onClick={() => handleSimulateRule(rule.id, rule.priorityChain, rule.customCheckUrls)}>
                                                             <FlaskConical className="w-4 h-4" />
                                                             Simulate Check
                                                         </DropdownMenuItem>

--- a/src/store/failoverStore.ts
+++ b/src/store/failoverStore.ts
@@ -644,6 +644,9 @@ export const useFailoverStore = create<FailoverStore>((set, get) => ({
                             activeUrl: (sr.activeUrl as string) || ((sr.priorityChain as string[]) || [])[0] as string | undefined,
                             lastCheck: sr.lastCheck ? new Date(sr.lastCheck as string | number) : undefined,
                             stabilization: (sr.stabilization as Record<string, number | AutopilotStabilizationEntry>) || {},
+                            webhookUrl: sr.webhookUrl as string | undefined,
+                            messageTemplate: sr.messageTemplate as string | undefined,
+                            customCheckUrls: (sr.customCheckUrls as CustomCheckEntry[]) || [],
                             status: 'idle'
                         }
 


### PR DESCRIPTION
Closes #37.

Three fixes in the failover path. They are separate bugs but one story: a rule
loses the health check you set, and nothing tells you.

**Rules rebuilt from the server keep their notification and health-check fields.**
`fetchAutopilotState` constructed each rule field by field and left out
`customCheckUrls`, `webhookUrl` and `messageTemplate`. Polling hid it, because
the local copy is merged in first; a logout empties that copy, so on re-login the
rule is built fresh and the fields are absent. Saving then wrote the absence
back, and `[]` clears the column. Duplicate Rule and Copy Rules From read the
same fields, so those lost the health check with no logout involved.

`messageTemplate` needed the server half too: `buildAutopilotState` did not
return it and neither state query selected the column.

**Simulate Check runs the applicable custom checks.** It only walked the priority
chain, so it could not reproduce the worker's verdict and passed on a URL the
worker was failing. It now applies the same scoping rule the worker uses, an
empty `appliesTo` covering every addon in the chain, and reports a failed check
as the reason rather than a bare failure. It goes through the existing
`/autopilot/test-url` endpoint, so client and server agree on what a passing
check is.

**A steadily healthy rule still records that it was checked.** `processRule`
returned `null` when nothing had changed, and `last_check` is only written from
that return, so a rule that settled at zero failures stopped updating its
timestamp entirely. In-memory runtime state hid it until a restart, after which
the UI read the frozen column and showed "Stale" on rules that were fine. A
heartbeat now persists at most every `AUTOPILOT_HEARTBEAT_PERSIST_MS`, default 5
minutes, which is inside the 15 minute threshold the badge uses. Steady rules go
from no writes to one per rule per 5 minutes, batched 100 to a statement. Lower
the interval or raise it if that trade is wrong for a large instance.

**Deliberately not included.** `notifyEnabled` has no column and is encoded as an
empty `webhookUrl`, which is also how "use the global default" is stored, so it
cannot round-trip without a migration. `lastFailover`, `platform` and
`connectionId` are also missing from the rebuild, but the last two have working
fallbacks and the first is display-only.

`npm run lint` and `npm run typecheck` both clean.

**Branched off `beta` rather than `main`.** CONTRIBUTING says `main`, but none of
this code is on it: `customCheckUrls` and the autopilot stats path do not exist
there. Happy to retarget if that is wrong.

— Milo #5574
