### PR TITLE
feat(reconciler): let an addon be held out of one platform

### DIFF
--- a/server/providers/reconciler.js
+++ b/server/providers/reconciler.js
@@ -24,6 +24,25 @@ function normalizeUrl(url) {
     return normalized.toLowerCase()
 }
 
+// An addon can be held out of one platform without leaving the account, so a
+// user who wants Cinemeta in Stremio but not in Nuvio no longer needs a second
+// account. The exclusion is applied when pushing rather than stored per
+// platform: the account keeps one canonical list and nothing gains a second
+// answer to "is this addon enabled".
+export function isExcludedFor(addon, platform) {
+    const list = addon?.flags?.excludePlatforms
+    return Array.isArray(list) && list.includes(platform)
+}
+
+// Returns the same array when nothing is excluded, so an account that has never
+// set an exclusion allocates nothing and takes the identical path as before.
+export function canonicalForPlatform(canonical, platform) {
+    if (!platform) return canonical
+    return canonical.some(a => isExcludedFor(a, platform))
+        ? canonical.filter(a => !isExcludedFor(a, platform))
+        : canonical
+}
+
 function diffAddons(canonical, platform) {
     const canonicalUrls = new Map(canonical.map(a => [normalizeUrl(a.transportUrl), a]))
     const platformUrls = new Map(platform.map(a => [normalizeUrl(a.transportUrl || a.url), a]))
@@ -426,15 +445,6 @@ export function createReconciler(fastify) {
             return { changes: [], canonical }
         }
 
-        const canonicalUrlSet = new Set(canonical.map(a => normalizeUrl(a.transportUrl)))
-        const canonicalManifestByUrl = new Map(
-            canonical.map(a => [normalizeUrl(a.transportUrl), manifestSignature(a.manifest)])
-        )
-        const customNameByUrl = new Map(
-            canonical
-                .filter(a => a?.metadata?.customName)
-                .map(a => [normalizeUrl(a.transportUrl), a.metadata.customName])
-        )
         const changes = []
 
         for (const connection of targetConnections) {
@@ -443,6 +453,20 @@ export function createReconciler(fastify) {
                 fastify.log.debug({ category: 'Reconciler' }, `[${accountId}] Skipping ${connection.platform} (${connId}): in backoff`)
                 continue
             }
+
+            // Derived per connection rather than once for the account: an addon
+            // excluded from this platform must be absent from the comparison as
+            // well as from the write, or every cycle reads it as drift.
+            const platformCanonical = canonicalForPlatform(canonical, connection.platform)
+            const canonicalUrlSet = new Set(platformCanonical.map(a => normalizeUrl(a.transportUrl)))
+            const canonicalManifestByUrl = new Map(
+                platformCanonical.map(a => [normalizeUrl(a.transportUrl), manifestSignature(a.manifest)])
+            )
+            const customNameByUrl = new Map(
+                platformCanonical
+                    .filter(a => a?.metadata?.customName)
+                    .map(a => [normalizeUrl(a.transportUrl), a.metadata.customName])
+            )
 
             try {
                 const driver = await loadDriver(connection.platform, connection.credentials || {}, connection)
@@ -473,7 +497,7 @@ export function createReconciler(fastify) {
                 } catch { /* can't read, assume needs write */ }
 
                 if (needsWrite) {
-                    await writePlatformAddons(driver, connection, canonical, 'reconcile')
+                    await writePlatformAddons(driver, connection, platformCanonical, 'reconcile')
                     changes.push({ type: 'restore', url: '', platform: connection.platform, primary: false })
                 }
                 recordSuccess(accountId, connId)
@@ -507,10 +531,11 @@ export function createReconciler(fastify) {
                     if (!stremioWriter) continue
                     await stremioWriter(connection)
                 } else {
-                    if (canon.length === 0) continue
+                    const platformCanon = canonicalForPlatform(canon, connection.platform)
+                    if (platformCanon.length === 0) continue
                     const driver = await loadDriver(connection.platform, connection.credentials || {}, connection)
                     if (!driver) continue
-                    await writePlatformAddons(driver, connection, canon, 'enforce')
+                    await writePlatformAddons(driver, connection, platformCanon, 'enforce')
                 }
                 recordSuccess(accountId, connId)
                 synced.push(connection.platform)

--- a/server/tests/platform-exceptions.test.js
+++ b/server/tests/platform-exceptions.test.js
@@ -1,0 +1,51 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { canonicalForPlatform, isExcludedFor } from '../providers/reconciler.js'
+
+const addon = (url, excludePlatforms) => ({
+    transportUrl: url,
+    flags: excludePlatforms ? { enabled: true, excludePlatforms } : { enabled: true },
+})
+
+test('an account with no exclusions gets the same array back', () => {
+    const canonical = [addon('https://a/manifest.json'), addon('https://b/manifest.json')]
+    // Identity, not just equality: an account that has never set an exclusion
+    // must not allocate a new list or take a different path.
+    assert.equal(canonicalForPlatform(canonical, 'nuvio'), canonical)
+    assert.equal(canonicalForPlatform(canonical, 'stremio'), canonical)
+})
+
+test('an excluded addon is withheld from that platform only', () => {
+    const cinemeta = addon('https://cinemeta/manifest.json', ['nuvio'])
+    const other = addon('https://other/manifest.json')
+    const canonical = [cinemeta, other]
+
+    const nuvio = canonicalForPlatform(canonical, 'nuvio')
+    assert.deepEqual(nuvio.map(a => a.transportUrl), ['https://other/manifest.json'])
+
+    const stremio = canonicalForPlatform(canonical, 'stremio')
+    assert.deepEqual(stremio.map(a => a.transportUrl), [
+        'https://cinemeta/manifest.json',
+        'https://other/manifest.json',
+    ])
+})
+
+test('excluding from several platforms withholds from each of them', () => {
+    const canonical = [addon('https://x/manifest.json', ['nuvio', 'realstream'])]
+    assert.equal(canonicalForPlatform(canonical, 'nuvio').length, 0)
+    assert.equal(canonicalForPlatform(canonical, 'realstream').length, 0)
+    assert.equal(canonicalForPlatform(canonical, 'stremio').length, 1)
+})
+
+test('a missing platform name withholds nothing', () => {
+    const canonical = [addon('https://x/manifest.json', ['nuvio'])]
+    assert.equal(canonicalForPlatform(canonical, undefined), canonical)
+    assert.equal(canonicalForPlatform(canonical, null), canonical)
+})
+
+test('a malformed exclusion is ignored rather than throwing', () => {
+    assert.equal(isExcludedFor({ flags: { excludePlatforms: 'nuvio' } }, 'nuvio'), false)
+    assert.equal(isExcludedFor({ flags: {} }, 'nuvio'), false)
+    assert.equal(isExcludedFor({}, 'nuvio'), false)
+    assert.equal(isExcludedFor(null, 'nuvio'), false)
+})

--- a/src/store/account/accountAddonOps.ts
+++ b/src/store/account/accountAddonOps.ts
@@ -594,6 +594,37 @@ export async function toggleAddonProtection(accountId: string, transportUrl: str
     }
 }
 
+// The addon stays on the account and stops being pushed to the platforms named
+// here. Passing an empty list clears the exclusion.
+export async function setAddonPlatformExclusions(accountId: string, transportUrl: string, platforms: string[], targetIndex?: number) {
+    const store = await getStore()
+    const releaseMutex = await acquireSyncMutex(accountId)
+    const account = getAccountById(store.getState().accounts, accountId)
+    if (!account) { releaseMutex(); return }
+    const prevAccounts = store.getState().accounts
+    try {
+        const excludePlatforms = Array.from(new Set((platforms || []).filter(p => typeof p === 'string' && p)))
+        const updatedAddons = account.addons.map((addon, index) =>
+            (targetIndex !== undefined ? index === targetIndex : normalizeAddonUrl(addon.transportUrl) === normalizeAddonUrl(transportUrl))
+                ? { ...addon, flags: { ...addon.flags, excludePlatforms } }
+                : addon
+        )
+        const updatedAccount = updateActiveProfile({ ...account, addons: updatedAddons }, updatedAddons)
+        const accounts = store.getState().accounts.map((acc) =>
+            acc.id === accountId ? updatedAccount : acc
+        )
+        store.setState({ accounts })
+        persistAccounts(accounts)
+        backgroundSync(accountId, account, updatedAddons)
+    } catch (e) {
+        store.setState({ accounts: prevAccounts })
+        persistAccounts(prevAccounts)
+        throw e
+    } finally {
+        releaseMutex()
+    }
+}
+
 export async function toggleAddonEnabled(accountId: string, transportUrl: string, isEnabled: boolean, silent = false, targetIndex?: number, isAutopilot = false) {
     const store = await getStore()
     const releaseMutex = await acquireSyncMutex(accountId)

--- a/src/store/accountStore.ts
+++ b/src/store/accountStore.ts
@@ -363,6 +363,12 @@ export interface AccountStore {
             isProtected: boolean,
             targetIndex?: number
       ) => Promise<void>
+      setAddonPlatformExclusions: (
+            accountId: string,
+            transportUrl: string,
+            platforms: string[],
+            targetIndex?: number
+      ) => Promise<void>
       toggleAddonEnabled: (
             accountId: string,
             transportUrl: string,
@@ -1021,6 +1027,11 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       toggleAddonProtection: async (accountId: string, transportUrl: string, isProtected: boolean, targetIndex?: number) => {
             const { toggleAddonProtection } = await import('./account/accountAddonOps')
             return toggleAddonProtection(accountId, transportUrl, isProtected, targetIndex)
+      },
+
+      setAddonPlatformExclusions: async (accountId: string, transportUrl: string, platforms: string[], targetIndex?: number) => {
+            const { setAddonPlatformExclusions } = await import('./account/accountAddonOps')
+            return setAddonPlatformExclusions(accountId, transportUrl, platforms, targetIndex)
       },
 
       toggleAddonEnabled: async (accountId: string, transportUrl: string, isEnabled: boolean, silent?: boolean, targetIndex?: number, isAutopilot?: boolean) => {


### PR DESCRIPTION
Closes #39.

`flags.excludePlatforms` on an addon names the platforms it should not reach. The account keeps one canonical list and the exclusion is applied when pushing, so nothing gains a second answer to "is this addon enabled".

**`reconcileAccount`** built its comparison maps once per account, so every platform saw the same set. They're now derived per connection from a filtered view, and that view is what gets written. Filtering only the write doesn't work: an excluded addon left in the drift comparison reads as drift every cycle, so it gets pushed anyway. **`enforceAccount`** filters on its own path too, and its empty-set guard now tests the filtered list.

`canonicalForPlatform` returns the same array, not a copy, when nothing is excluded — an account with no exclusions allocates nothing and takes the identical path. The first test asserts identity rather than equality to keep that true.

Setting it: `setAddonPlatformExclusions(accountId, transportUrl, platforms, targetIndex?)`, exposed on the account store, mirroring `toggleAddonProtection`. Persistence needed nothing — flags already merge and round-trip.

5 tests in `server/tests/platform-exceptions.test.js` under the existing `node --test` runner, `tsc --noEmit` clean. `server/tests/*` is gitignored so it's added with `-f`, matching `static-serving.test.js` and `helpers.js`. That existing test fails in a clean checkout before this change too — it wants `server/data/server_secret.key`.

Scope: `targetConnections` filters Stremio out of server-side reconciliation unless the connection is Hydra outbound, so this covers Nuvio and RealStream. Excluding from Stremio needs the client pipeline. An excluded addon is removed from that platform on the next push, since the push writes the full set — that's what the request asks for, but worth naming.

**No UI control**, deliberately. The chain is mutation → store → `AddonCard.tsx` and this does the first two. The last one isn't style-matching: an exclusion is a multi-select over whichever platforms an account has connected, not a boolean like `protected`, so where it sits on the card and how it reads for a single-connection account are product calls rather than mine. Name the shape and I'll add it, or take it — the store method is all a control calls.

If you'd rather the exclusion lived on the connection than the addon, the filter works the same and the diff is small.

*— Milo#5574*
