### PR TITLE
fix(activity): page accounts by id so a rotation cannot skip one

### DIFF
--- a/server/activity/engine.js
+++ b/server/activity/engine.js
@@ -49,7 +49,7 @@ const SNAPSHOT_COMPARE_COLUMNS = SNAPSHOT_COLUMNS.filter(col => !['sync_user', '
 let scanTimer = null
 let isStarted = false
 let isScanning = false
-let credentialCursor = 0
+let credentialCursor = ''
 let nonStremioSkipWarned = false
 const accountStateHashes = new Map()
 
@@ -162,33 +162,37 @@ function computeLibraryHash(library) {
     return hashString(raw)
 }
 
-async function getRegisteredAccountsPage(limit, offset = 0) {
+async function getRegisteredAccountsPage(limit, afterId = '') {
     // Stremio-only: Nuvio/RealStream auth_key rows are JSON token bundles, not Stremio authKeys.
+    // Keyed on id rather than an offset: updated_at is written mid-rotation by
+    // token refresh and credential upsert, which moved rows past the cursor and
+    // left those accounts unscanned for the rest of the rotation.
     return db.query(
-        `SELECT sync_user, account_id, account_name, auth_key
+        `SELECT sync_user, account_id, account_name, auth_key, id
          FROM server_credentials
-         WHERE credential_type = 'stremio' OR credential_type IS NULL
-         ORDER BY updated_at DESC, id ASC
-         LIMIT $1 OFFSET $2`,
-        [limit, offset]
+         WHERE (credential_type = 'stremio' OR credential_type IS NULL)
+           AND ($2 = '' OR id > $2)
+         ORDER BY id ASC
+         LIMIT $1`,
+        [limit, afterId]
     )
 }
 
 async function getAccountsForCycle() {
     const limit = ACTIVITY_MAX_ACCOUNTS_PER_CYCLE
     let selected = await getRegisteredAccountsPage(limit, credentialCursor)
-    let wrappedCount = 0
 
-    if (selected.length === 0 && credentialCursor > 0) {
-        credentialCursor = 0
-        selected = await getRegisteredAccountsPage(limit, 0)
-    } else if (selected.length < limit && credentialCursor > 0) {
-        const wrapped = await getRegisteredAccountsPage(limit - selected.length, 0)
-        wrappedCount = wrapped.length
+    if (selected.length === 0 && credentialCursor !== '') {
+        credentialCursor = ''
+        selected = await getRegisteredAccountsPage(limit, '')
+    } else if (selected.length < limit && credentialCursor !== '') {
+        const wrapped = await getRegisteredAccountsPage(limit - selected.length, '')
         selected = [...selected, ...wrapped]
     }
 
-    credentialCursor = selected.length < limit ? 0 : (wrappedCount > 0 ? wrappedCount : credentialCursor + selected.length)
+    // The cursor is the last id handed out, so the next cycle resumes after it
+    // regardless of what happened to any row's updated_at in the meantime.
+    credentialCursor = selected.length < limit ? '' : selected[selected.length - 1].id
     return selected
 }
 


### PR DESCRIPTION
# fix(activity): page accounts by id so a rotation cannot skip one

Closes issue #43.

`getAccountsForCycle` paged with LIMIT/OFFSET over `ORDER BY updated_at DESC`.
`updated_at` changes during a rotation (token refresh, credential upsert), so
rows shifted past the cursor and were not selected.

## Change

    -   ORDER BY updated_at DESC, id ASC
    -   LIMIT $1 OFFSET $2
    +   AND id > $2
    +   ORDER BY id ASC
    +   LIMIT $1

`credentialCursor` holds the last `id` returned instead of a row count, and
resets to `''` on wrap. Selection no longer depends on a mutable column, so every
account is visited once per rotation.

## What this drops

The `updated_at DESC` ordering, which expressed "scan recently active first".

It was not delivering that: the walk reaches every account each rotation anyway,
so the ordering only decided position within a rotation — and it is the thing
causing the skips. A recency preference wants a priority lane rather than a sort
order over a paged walk.

## Tests

Not included, and I would rather say why than leave it out quietly.
`getAccountsForCycle` is not exported and `credentialCursor` is module state, so
there is no way to drive a rotation from a test as the module stands. Exporting
it, or having it take and return the cursor, would make it testable — happy to do
either if you want it, but that is a change to your module's shape rather than a
bug fix, so it is your call rather than mine.

Verified by reproducing the paging behaviour outside the repo; the before and
after are in the issue.

Target: `beta`.

*— Milo#5574*
