### PR TITLE
fix(activity): keep an account in the scan rotation when it re-logs in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage
 # Tests stay local except the CI smoke suite, which must run in CI
 server/tests/*
 !server/tests/static-serving.test.js
+!server/tests/activity-rotation.test.js
 !server/tests/helpers.js
 src/**/*.test.ts
 

--- a/server/activity/engine.js
+++ b/server/activity/engine.js
@@ -49,7 +49,7 @@ const SNAPSHOT_COMPARE_COLUMNS = SNAPSHOT_COLUMNS.filter(col => !['sync_user', '
 let scanTimer = null
 let isStarted = false
 let isScanning = false
-let credentialCursor = 0
+let credentialCursor = ''
 let nonStremioSkipWarned = false
 const accountStateHashes = new Map()
 
@@ -162,33 +162,31 @@ function computeLibraryHash(library) {
     return hashString(raw)
 }
 
-async function getRegisteredAccountsPage(limit, offset = 0) {
+async function getRegisteredAccountsPage(limit, afterId = '') {
     // Stremio-only: Nuvio/RealStream auth_key rows are JSON token bundles, not Stremio authKeys.
+    // Keyset on the primary key. updated_at moves when an account re-logs in, and an
+    // OFFSET page over a moving sort key skips rows.
     return db.query(
-        `SELECT sync_user, account_id, account_name, auth_key
+        `SELECT id, sync_user, account_id, account_name, auth_key
          FROM server_credentials
-         WHERE credential_type = 'stremio' OR credential_type IS NULL
-         ORDER BY updated_at DESC, id ASC
-         LIMIT $1 OFFSET $2`,
-        [limit, offset]
+         WHERE (credential_type = 'stremio' OR credential_type IS NULL) AND id > $1
+         ORDER BY id ASC
+         LIMIT $2`,
+        [afterId, limit]
     )
 }
 
-async function getAccountsForCycle() {
+export async function getAccountsForCycle() {
     const limit = ACTIVITY_MAX_ACCOUNTS_PER_CYCLE
     let selected = await getRegisteredAccountsPage(limit, credentialCursor)
-    let wrappedCount = 0
 
-    if (selected.length === 0 && credentialCursor > 0) {
-        credentialCursor = 0
-        selected = await getRegisteredAccountsPage(limit, 0)
-    } else if (selected.length < limit && credentialCursor > 0) {
-        const wrapped = await getRegisteredAccountsPage(limit - selected.length, 0)
-        wrappedCount = wrapped.length
-        selected = [...selected, ...wrapped]
+    if (selected.length < limit && credentialCursor !== '') {
+        const seen = new Set(selected.map(row => row.id))
+        const wrapped = await getRegisteredAccountsPage(limit - selected.length, '')
+        selected = [...selected, ...wrapped.filter(row => !seen.has(row.id))]
     }
 
-    credentialCursor = selected.length < limit ? 0 : (wrappedCount > 0 ? wrappedCount : credentialCursor + selected.length)
+    credentialCursor = selected.length > 0 ? selected[selected.length - 1].id : ''
     return selected
 }
 

--- a/server/tests/activity-rotation.test.js
+++ b/server/tests/activity-rotation.test.js
@@ -1,0 +1,102 @@
+process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes-long!!'
+process.env.ACTIVITY_MAX_ACCOUNTS_PER_CYCLE = '50'
+
+import test, { before, after } from 'node:test'
+import assert from 'node:assert/strict'
+
+import db from '../db.js'
+import { setupTestEnv, cleanupTestEnv } from './helpers.js'
+import { getAccountsForCycle } from '../activity/engine.js'
+
+const PAGE = 50
+
+// The engine's rotation cursor is module state and carries across tests. Each case
+// below measures a full pass over the table as it stands, which holds from any start.
+
+// updated_at ascends with the index, so under `ORDER BY updated_at DESC` account 0
+// sits last and account N-1 first.
+async function seed(count) {
+    await db.run('DELETE FROM server_credentials')
+    for (let i = 0; i < count; i++) {
+        await db.run(
+            `INSERT INTO server_credentials (id, sync_user, account_id, account_name, auth_key, credential_type, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            [`cred-${String(i).padStart(4, '0')}`, 'user', `acct-${i}`, `name-${i}`, 'key', 'stremio', 1_000_000 + i]
+        )
+    }
+}
+
+async function collect(cycles, onCycle = null) {
+    const seen = new Set()
+    for (let cycle = 0; cycle < cycles; cycle++) {
+        for (const row of await getAccountsForCycle()) seen.add(row.account_id)
+        if (onCycle) await onCycle(cycle)
+    }
+    return seen
+}
+
+// What routes/activity.js writes when a client pushes a changed authKey.
+function reLogin(accountId) {
+    return db.run('UPDATE server_credentials SET updated_at = $1 WHERE account_id = $2', [Date.now(), accountId])
+}
+
+function missing(seen, count) {
+    const missed = []
+    for (let i = 0; i < count; i++) if (!seen.has(`acct-${i}`)) missed.push(`acct-${i}`)
+    return missed
+}
+
+before(async () => { await setupTestEnv() })
+after(() => cleanupTestEnv())
+
+test('every account is reached in ceil(count / page) cycles', async () => {
+    for (const count of [1, 7, 49, 50, 51, 120, 200]) {
+        await seed(count)
+        const cycles = Math.ceil(count / PAGE)
+        assert.deepEqual(missing(await collect(cycles), count), [], `${count} accounts in ${cycles} cycles`)
+    }
+})
+
+test('an account that re-logs in mid-rotation is still scanned', async () => {
+    const count = 200
+    for (const target of [199, 150, 100, 50, 10, 0]) {
+        await seed(count)
+        const seen = await collect(Math.ceil(count / PAGE), cycle => (cycle === 0 ? reLogin(`acct-${target}`) : null))
+        assert.deepEqual(missing(seen, count), [], `acct-${target} re-logged in during the rotation`)
+    }
+})
+
+test('an account registering mid-rotation does not displace an existing one', async () => {
+    const count = 200
+    await seed(count)
+    // The table holds count + 1 rows once the registration lands, so a full pass is one cycle longer.
+    const seen = await collect(Math.ceil((count + 1) / PAGE), cycle => (cycle === 0
+        ? db.run(
+            `INSERT INTO server_credentials (id, sync_user, account_id, account_name, auth_key, credential_type, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            ['cred-new', 'user', 'acct-new', 'name-new', 'key', 'stremio', Date.now()])
+        : null))
+    assert.deepEqual(missing(seen, count), [])
+})
+
+test('a deletion mid-rotation does not strand the accounts behind it', async () => {
+    await seed(200)
+    const seen = await collect(4, cycle => (cycle === 1
+        ? db.run("DELETE FROM server_credentials WHERE account_id IN ('acct-150', 'acct-151', 'acct-152')")
+        : null))
+    const remaining = (await db.query('SELECT account_id FROM server_credentials')).map(row => row.account_id)
+    assert.deepEqual(remaining.filter(id => !seen.has(id)), [])
+})
+
+test('a cycle never hands back the same account twice', async () => {
+    await seed(30)
+    for (let cycle = 0; cycle < 3; cycle++) {
+        const ids = (await getAccountsForCycle()).map(row => row.account_id)
+        assert.equal(new Set(ids).size, ids.length)
+    }
+})
+
+test('an empty credential table yields an empty cycle', async () => {
+    await db.run('DELETE FROM server_credentials')
+    assert.deepEqual(await getAccountsForCycle(), [])
+})


### PR DESCRIPTION
## What's wrong

`getAccountsForCycle` pages with `LIMIT`/`OFFSET` over `ORDER BY updated_at DESC`,
and `/api/credentials/sync` rewrites `updated_at` whenever a client pushes a
changed authKey. An account that re-logs in mid-rotation moves to the front of
the ordering, behind the cursor, so the remaining pages step past it and it is
not scanned until the next rotation.

It only affects accounts the cursor has not reached yet, which is most of them
once an instance is larger than one page.

## Reproducing

200 accounts, `ACTIVITY_MAX_ACCOUNTS_PER_CYCLE=50`, one re-login after the first
cycle. Against `beta`:

    position in the rotation      that account
      0  (already scanned)        scanned
     49  (already scanned)        scanned
     99                           SKIPPED
    149                           SKIPPED
    189                           SKIPPED
    199                           SKIPPED

That case is the second test in the added file. It fails on `beta` and passes
with the change.

## The change

Keyset on `id` rather than an offset over `updated_at`. No write moves a row's
primary key, so the cursor cannot be overtaken.

Coverage is unchanged at `ceil(count / page)` cycles for a full pass, checked at
1, 7, 49, 50, 51, 120 and 200 accounts, along with deletion mid-rotation, an
empty table, and a page smaller than the cycle limit.

Two things worth flagging:

- The old ordering meant a cold start scanned the most recently updated accounts
  first. Ordering by `id` gives that up. Happy to add a priority first pass if
  you would rather keep it.
- `getAccountsForCycle` is exported for the test; nothing else outside the module
  uses it.
- `.gitignore` needed one allowlist line for the new test, following the existing
  `static-serving.test.js` entry.

`npm --prefix server run test:smoke` passes 11/11.

*— Milo#5574*
