### PR TITLE
ci: build each arch on a native runner instead of emulating arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,11 +26,22 @@ jobs:
       - run: npm run typecheck
 
   build:
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     needs: [client-gate]
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: Checkout repository
@@ -51,8 +62,82 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.11.1
+
+      # Pull requests build as a check and publish nothing, so they stop here
+      # rather than pushing a digest with no manifest to point at it.
+      - name: Build (pull request check)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          pull: true
+          push: false
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Build and push by digest
+        id: build
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          pull: true
+          outputs: |
+            type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+            type=image,name=${{ env.DOCKER_HUB_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      # The digest is a hash of the image itself, so both registries hold the
+      # same one and the merge job can build either manifest from this file.
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.5.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3.5.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
@@ -71,14 +156,18 @@ jobs:
             type=semver,pattern={{version}}
             type=sha
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6.18.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          pull: true
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          for image in "${REGISTRY}/${IMAGE_NAME}" "${DOCKER_HUB_IMAGE}"; do
+            tag_args=()
+            while read -r tag; do
+              [ -n "$tag" ] || continue
+              case "$tag" in
+                "${image}:"*) tag_args+=(-t "$tag") ;;
+              esac
+            done <<< '${{ steps.meta.outputs.tags }}'
+            [ ${#tag_args[@]} -gt 0 ] || continue
+            docker buildx imagetools create "${tag_args[@]}" \
+              $(printf "${image}@sha256:%s " *)
+          done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,6 +62,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # ghcr rejects an uppercase path and github.repository preserves the
+      # owner's casing, so the name is lowered before it reaches a ref.
+      - name: Compute the ghcr image name
+        id: img
+        run: echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
 
@@ -87,7 +93,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           pull: true
           outputs: |
-            type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+            type=image,name=${{ env.REGISTRY }}/${{ steps.img.outputs.name }},push-by-digest=true,name-canonical=true,push=true
             type=image,name=${{ env.DOCKER_HUB_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
@@ -159,7 +165,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          for image in "${REGISTRY}/${IMAGE_NAME}" "${DOCKER_HUB_IMAGE}"; do
+          for image in "${REGISTRY}/${IMAGE_NAME,,}" "${DOCKER_HUB_IMAGE}"; do
             tag_args=()
             while read -r tag; do
               [ -n "$tag" ] || continue


### PR DESCRIPTION
Builds `linux/amd64` and `linux/arm64` on their own native runners instead of emulating arm64 through QEMU on one x86 runner.

The Dockerfile compiles native modules (`python3 make g++` for node-gyp) and runs `npm ci` twice plus a Vite build. Under emulation the arm64 half of that costs roughly ten times what it costs natively, and it is most of the build.

### Numbers

Measured on a fork of this repo, same commit, cold caches, two rounds:

| | round 1 | round 2 | mean |
|---|---|---|---|
| QEMU, both arches (current) | 15.60 | 14.10 | 14.85 min |
| QEMU, arm64 alone | 12.75 | 10.58 | 11.67 min |
| Native amd64 | 2.48 | 2.27 | 2.38 min |
| Native arm64 | 2.38 | 2.47 | 2.43 min |

The two native jobs run in parallel, so the wall clock is the slower of them plus the merge job.

Verified end to end on the fork with a real push, not just a benchmark:

```
client-gate         0.92 min
Build linux/amd64   2.45 min   } in parallel
Build linux/arm64   2.53 min   }
merge               0.53 min
```

So about **3.1 minutes** from build start to a published manifest. Against this repo's own recent history for the current setup (9.0 to 16.6 minutes, median 10.4) that is roughly **3.4x**, saving around 7 minutes a build. Against my own controlled runs of the current setup it is 4.9x, but those both landed at the slow end of what this repo normally does, so the median is the fairer comparison.

`ubuntu-24.04-arm` is a GitHub-hosted runner and is free for public repositories.

### What does not change

`client-gate` still gates the build. Both registries, all five tag rules including `edge` on beta, `pull: true`, and the pinned action versions are all as they were. Pull requests still build both arches as a check and publish nothing.

The published result is an OCI image index with both platforms, same as now. On the fork it came out with `edge`, `beta` and `sha-<short>` applied correctly.

### One thing I could not test

The Docker Hub half. A fork has no `DOCKER_USERNAME`, so I verified the whole path against GHCR only. The Docker Hub lines are the same pattern pointed at the other name, but they are untested and I would rather say so than imply otherwise.

### One bug worth knowing about

The first version of this failed because `github.repository` keeps the owner's capitalisation and GHCR rejects an uppercase path. The current workflow never hits it because `docker/metadata-action` lowercases internally, and writing the name straight into `outputs:` skips that. There is now a small step that lowers it. Mentioning it because it would have bitten anyone making this change.

### A note on the branch

CONTRIBUTING.md says to branch off `main` and open PRs against `main`. I have targeted `beta` instead, on the basis that it is the staging branch and carries the newer copy of this workflow, so a change against `main` would conflict. Happy to retarget if that is wrong.

### Runs behind the numbers

Benchmark rounds and the end-to-end publish, on the fork:

- benchmark round 1: https://github.com/IbbyLabs/AIOManager/actions/runs/32917875127
- benchmark round 2: https://github.com/IbbyLabs/AIOManager/actions/runs/32918913125
- end-to-end publish (GHCR): https://github.com/IbbyLabs/AIOManager/actions/runs/32920109185

Note that this PR shows no checks of its own: the `pull_request` trigger in this workflow is scoped to `main`, so a PR onto `beta` does not start one. That is how it already was and this change does not alter it.

*— Bob#1570*

