### PR TITLE
Add "Allow external addon management" option per account

### DIFF
--- a/src/components/accounts/AccountForm.tsx
+++ b/src/components/accounts/AccountForm.tsx
@@ -12,6 +12,13 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useAccounts } from '@/hooks/useAccounts'
 import { useUIStore } from '@/store/uiStore'
 import { useAccountStore, hasPlatformConnection, getStremioAuthKey } from '@/store/accountStore'
@@ -110,6 +117,7 @@ export function AccountForm() {
   const [hideAddonPreview, setHideAddonPreview] = useState(false)
   const [hidePlatformLogos, setHidePlatformLogos] = useState(false)
   const [allowExternalAddonManagement, setAllowExternalAddonManagement] = useState(false)
+  const [sourceOfTruth, setSourceOfTruth] = useState<string | undefined>(undefined)
   const connectionSubDialogRef = useRef(false)
   const subDialogClosedAtRef = useRef(0)
 
@@ -155,6 +163,7 @@ export function AccountForm() {
       setHideAddonPreview(editingAccount.hideAddonPreview ?? false)
       setHidePlatformLogos(editingAccount.hidePlatformLogos ?? false)
       setAllowExternalAddonManagement(editingAccount.allowExternalAddonManagement ?? false)
+      setSourceOfTruth(editingAccount.sourceOfTruth)
     } else {
       setMode('credentials')
       setAuthIntent('login')
@@ -169,6 +178,7 @@ export function AccountForm() {
       setHideAddonPreview(false)
       setHidePlatformLogos(false)
       setAllowExternalAddonManagement(false)
+      setSourceOfTruth(undefined)
     }
   }, [editingAccount, isOpen])
 
@@ -245,6 +255,7 @@ export function AccountForm() {
             hideAddonPreview,
             hidePlatformLogos,
             allowExternalAddonManagement,
+sourceOfTruth,
           })
         } else {
           await addAccountByCredentials(
@@ -269,6 +280,7 @@ export function AccountForm() {
             hideAddonPreview,
             hidePlatformLogos,
             allowExternalAddonManagement,
+sourceOfTruth,
           })
         } else {
           await addAccountByAuthKey(
@@ -288,6 +300,7 @@ export function AccountForm() {
           if (allowExternalAddonManagement || hideLastWatched || hideAddonPreview || hidePlatformLogos) {
             await updateAccount(newAccount.id, {
               allowExternalAddonManagement,
+sourceOfTruth,
               hideLastWatched,
               hideAddonPreview,
               hidePlatformLogos
@@ -517,6 +530,7 @@ export function AccountForm() {
           hideAddonPreview,
           hidePlatformLogos,
           allowExternalAddonManagement,
+sourceOfTruth,
         })
       } else {
         if (mode === 'authKey') {
@@ -541,6 +555,7 @@ export function AccountForm() {
           if (allowExternalAddonManagement || hideLastWatched || hideAddonPreview || hidePlatformLogos) {
             await updateAccount(newAccount.id, {
               allowExternalAddonManagement,
+sourceOfTruth,
               hideLastWatched,
               hideAddonPreview,
               hidePlatformLogos
@@ -1168,6 +1183,29 @@ export function AccountForm() {
             onCheckedChange={setAllowExternalAddonManagement}
           />
         </div>
+        
+        {allowExternalAddonManagement && (
+          <div className="flex flex-col gap-2 py-2">
+            <div>
+              <p className="text-sm font-medium">Source of Truth App</p>
+              <p className="text-xs text-muted-foreground">Select which connected client acts as the source of truth for your addons.</p>
+            </div>
+            <Select value={sourceOfTruth || 'auto'} onValueChange={(val) => setSourceOfTruth(val === 'auto' ? undefined : val)}>
+              <SelectTrigger className="w-full h-11 bg-background/50 border-muted">
+                <SelectValue placeholder="Automatic (Default)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">Automatic (Default)</SelectItem>
+                {getStremioAuthKey(liveAccount || editingAccount || { authKey: authKey, addons: [], lastSync: new Date(), id: '', name: '', status: 'active' } as any) && (
+                  <SelectItem value="stremio-native">Stremio (Native)</SelectItem>
+                )}
+                {((liveAccount || editingAccount)?.connections || []).filter(c => c.enabled).map(conn => (
+                  <SelectItem key={conn.id} value={conn.id}>{conn.platform} ({conn.credentials?.email || conn.credentials?.profileId || 'Connection'})</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
       </div>
 
       {error && (
@@ -1577,6 +1615,29 @@ export function AccountForm() {
                   onCheckedChange={setAllowExternalAddonManagement}
                 />
               </div>
+              
+              {allowExternalAddonManagement && (
+                <div className="flex flex-col gap-2 py-2">
+                  <div>
+                    <p className="text-sm font-medium">Source of Truth App</p>
+                    <p className="text-xs text-muted-foreground">Select which connected client acts as the source of truth for your addons.</p>
+                  </div>
+                  <Select value={sourceOfTruth || 'auto'} onValueChange={(val) => setSourceOfTruth(val === 'auto' ? undefined : val)}>
+                    <SelectTrigger className="w-full h-11 bg-background/50 border-muted">
+                      <SelectValue placeholder="Automatic (Default)" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="auto">Automatic (Default)</SelectItem>
+                      {getStremioAuthKey(liveAccount || editingAccount || { authKey: authKey, addons: [], lastSync: new Date(), id: '', name: '', status: 'active' } as any) && (
+                        <SelectItem value="stremio-native">Stremio (Native)</SelectItem>
+                      )}
+                      {((liveAccount || editingAccount)?.connections || []).filter(c => c.enabled).map(conn => (
+                        <SelectItem key={conn.id} value={conn.id}>{conn.platform} ({conn.credentials?.email || conn.credentials?.profileId || 'Connection'})</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
             </div>
           </div>
         </TabsContent>

--- a/src/components/accounts/AccountForm.tsx
+++ b/src/components/accounts/AccountForm.tsx
@@ -255,7 +255,7 @@ export function AccountForm() {
             hideAddonPreview,
             hidePlatformLogos,
             allowExternalAddonManagement,
-sourceOfTruth,
+            sourceOfTruth,
           })
         } else {
           await addAccountByCredentials(
@@ -280,7 +280,7 @@ sourceOfTruth,
             hideAddonPreview,
             hidePlatformLogos,
             allowExternalAddonManagement,
-sourceOfTruth,
+            sourceOfTruth,
           })
         } else {
           await addAccountByAuthKey(
@@ -300,7 +300,7 @@ sourceOfTruth,
           if (allowExternalAddonManagement || hideLastWatched || hideAddonPreview || hidePlatformLogos) {
             await updateAccount(newAccount.id, {
               allowExternalAddonManagement,
-sourceOfTruth,
+              sourceOfTruth,
               hideLastWatched,
               hideAddonPreview,
               hidePlatformLogos
@@ -530,7 +530,7 @@ sourceOfTruth,
           hideAddonPreview,
           hidePlatformLogos,
           allowExternalAddonManagement,
-sourceOfTruth,
+          sourceOfTruth,
         })
       } else {
         if (mode === 'authKey') {
@@ -555,7 +555,7 @@ sourceOfTruth,
           if (allowExternalAddonManagement || hideLastWatched || hideAddonPreview || hidePlatformLogos) {
             await updateAccount(newAccount.id, {
               allowExternalAddonManagement,
-sourceOfTruth,
+              sourceOfTruth,
               hideLastWatched,
               hideAddonPreview,
               hidePlatformLogos

--- a/src/components/accounts/AccountForm.tsx
+++ b/src/components/accounts/AccountForm.tsx
@@ -79,6 +79,8 @@ const ACCOUNT_AUTH_METHODS: Array<{ id: AccountAuthMode; label: string; subtitle
   { id: 'authKey', label: 'Auth Key', subtitle: 'Paste an existing token for advanced imports.', icon: KeyRound },
 ]
 
+const capitalize = (str: string) => str ? str.charAt(0).toUpperCase() + str.slice(1) : ''
+
 export function AccountForm() {
   const isOpen = useUIStore((state) => state.isAddAccountDialogOpen)
   const closeDialog = useUIStore((state) => state.closeAddAccountDialog)
@@ -123,6 +125,18 @@ export function AccountForm() {
 
   const isEditing = !!editingAccount
   const isExpiredSession = editingAccount?.status === 'expired'
+
+  const getAutoSourceLabel = () => {
+    const account = liveAccount || editingAccount || { authKey: authKey, addons: [], lastSync: new Date(), id: '', name: '', status: 'active', connections: [] } as any
+    const nuvioConn = account.connections?.find((c: any) => c.enabled && c.platform === 'nuvio')
+    if (nuvioConn) return 'Nuvio'
+    const stremioConn = account.connections?.find((c: any) => c.enabled && c.platform === 'stremio')
+    if (stremioConn) return 'Stremio'
+    if (getStremioAuthKey(account)) return 'Stremio'
+    const otherConn = account.connections?.find((c: any) => c.enabled)
+    if (otherConn) return capitalize(otherConn.platform)
+    return 'None'
+  }
 
   useEffect(() => {
     setOauthAuthKey('')
@@ -1192,15 +1206,15 @@ export function AccountForm() {
             </div>
             <Select value={sourceOfTruth || 'auto'} onValueChange={(val) => setSourceOfTruth(val === 'auto' ? undefined : val)}>
               <SelectTrigger className="w-full h-11 bg-background/50 border-muted">
-                <SelectValue placeholder="Automatic (Default)" />
+                <SelectValue placeholder={`Default (${getAutoSourceLabel()})`} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="auto">Automatic (Default)</SelectItem>
+                <SelectItem value="auto">Default ({getAutoSourceLabel()})</SelectItem>
                 {getStremioAuthKey(liveAccount || editingAccount || { authKey: authKey, addons: [], lastSync: new Date(), id: '', name: '', status: 'active' } as any) && (
                   <SelectItem value="stremio-native">Stremio (Native)</SelectItem>
                 )}
                 {((liveAccount || editingAccount)?.connections || []).filter(c => c.enabled).map(conn => (
-                  <SelectItem key={conn.id} value={conn.id}>{conn.platform} ({conn.credentials?.email || conn.credentials?.profileId || 'Connection'})</SelectItem>
+                  <SelectItem key={conn.id} value={conn.id}>{capitalize(conn.platform)} ({conn.credentials?.email || conn.credentials?.profileId || 'Connection'})</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -1624,15 +1638,15 @@ export function AccountForm() {
                   </div>
                   <Select value={sourceOfTruth || 'auto'} onValueChange={(val) => setSourceOfTruth(val === 'auto' ? undefined : val)}>
                     <SelectTrigger className="w-full h-11 bg-background/50 border-muted">
-                      <SelectValue placeholder="Automatic (Default)" />
+                      <SelectValue placeholder={`Default (${getAutoSourceLabel()})`} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="auto">Automatic (Default)</SelectItem>
+                      <SelectItem value="auto">Default ({getAutoSourceLabel()})</SelectItem>
                       {getStremioAuthKey(liveAccount || editingAccount || { authKey: authKey, addons: [], lastSync: new Date(), id: '', name: '', status: 'active' } as any) && (
                         <SelectItem value="stremio-native">Stremio (Native)</SelectItem>
                       )}
                       {((liveAccount || editingAccount)?.connections || []).filter(c => c.enabled).map(conn => (
-                        <SelectItem key={conn.id} value={conn.id}>{conn.platform} ({conn.credentials?.email || conn.credentials?.profileId || 'Connection'})</SelectItem>
+                        <SelectItem key={conn.id} value={conn.id}>{capitalize(conn.platform)} ({conn.credentials?.email || conn.credentials?.profileId || 'Connection'})</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>

--- a/src/components/accounts/AccountForm.tsx
+++ b/src/components/accounts/AccountForm.tsx
@@ -109,6 +109,7 @@ export function AccountForm() {
   const [hideLastWatched, setHideLastWatched] = useState(false)
   const [hideAddonPreview, setHideAddonPreview] = useState(false)
   const [hidePlatformLogos, setHidePlatformLogos] = useState(false)
+  const [allowExternalAddonManagement, setAllowExternalAddonManagement] = useState(false)
   const connectionSubDialogRef = useRef(false)
   const subDialogClosedAtRef = useRef(0)
 
@@ -153,6 +154,7 @@ export function AccountForm() {
       setHideLastWatched(editingAccount.hideLastWatched ?? false)
       setHideAddonPreview(editingAccount.hideAddonPreview ?? false)
       setHidePlatformLogos(editingAccount.hidePlatformLogos ?? false)
+      setAllowExternalAddonManagement(editingAccount.allowExternalAddonManagement ?? false)
     } else {
       setMode('credentials')
       setAuthIntent('login')
@@ -164,6 +166,9 @@ export function AccountForm() {
       setEmoji('')
       setAvatar('')
       setHideLastWatched(false)
+      setHideAddonPreview(false)
+      setHidePlatformLogos(false)
+      setAllowExternalAddonManagement(false)
     }
   }, [editingAccount, isOpen])
 
@@ -239,6 +244,7 @@ export function AccountForm() {
             hideLastWatched,
             hideAddonPreview,
             hidePlatformLogos,
+            allowExternalAddonManagement,
           })
         } else {
           await addAccountByCredentials(
@@ -262,6 +268,7 @@ export function AccountForm() {
             hideLastWatched,
             hideAddonPreview,
             hidePlatformLogos,
+            allowExternalAddonManagement,
           })
         } else {
           await addAccountByAuthKey(
@@ -278,6 +285,14 @@ export function AccountForm() {
       } else if (beforeIds) {
         const newAccount = useAccountStore.getState().accounts.find(a => !beforeIds.has(a.id))
         if (newAccount) {
+          if (allowExternalAddonManagement || hideLastWatched || hideAddonPreview || hidePlatformLogos) {
+            await updateAccount(newAccount.id, {
+              allowExternalAddonManagement,
+              hideLastWatched,
+              hideAddonPreview,
+              hidePlatformLogos
+            })
+          }
           setCreatedAccountId(newAccount.id)
           setConnectedPlatforms(prev => new Set(prev).add('stremio'))
           setWizardStep('connect-more')
@@ -501,6 +516,7 @@ export function AccountForm() {
           hideLastWatched,
           hideAddonPreview,
           hidePlatformLogos,
+          allowExternalAddonManagement,
         })
       } else {
         if (mode === 'authKey') {
@@ -522,6 +538,14 @@ export function AccountForm() {
       } else if (beforeIds) {
         const newAccount = useAccountStore.getState().accounts.find(a => !beforeIds.has(a.id))
         if (newAccount) {
+          if (allowExternalAddonManagement || hideLastWatched || hideAddonPreview || hidePlatformLogos) {
+            await updateAccount(newAccount.id, {
+              allowExternalAddonManagement,
+              hideLastWatched,
+              hideAddonPreview,
+              hidePlatformLogos
+            })
+          }
           setCreatedAccountId(newAccount.id)
           setConnectedPlatforms(prev => new Set(prev).add('stremio'))
           setWizardStep('connect-more')
@@ -1098,6 +1122,7 @@ export function AccountForm() {
 
       {isEditing && (
         <div className="border-t border-border/10 pt-4 space-y-1">
+          <Label className="text-xs font-medium text-muted-foreground uppercase">Card Options</Label>
           <div className="flex items-center justify-between py-2">
             <div>
               <p className="text-sm font-medium">Hide last watched</p>
@@ -1130,6 +1155,20 @@ export function AccountForm() {
           </div>
         </div>
       )}
+
+      <div className="border-t border-border/10 pt-4 space-y-1">
+        <Label className="text-xs font-medium text-muted-foreground uppercase">Sync Options</Label>
+        <div className="flex items-center justify-between py-2">
+          <div>
+            <p className="text-sm font-medium">Allow external addon management</p>
+            <p className="text-xs text-muted-foreground">Sync addon changes made from connected apps directly to AIOManager.</p>
+          </div>
+          <Switch
+            checked={allowExternalAddonManagement}
+            onCheckedChange={setAllowExternalAddonManagement}
+          />
+        </div>
+      </div>
 
       {error && (
         <div className="bg-destructive/10 border border-destructive/50 rounded-xl px-4 py-3 animate-in shake duration-500">
@@ -1522,6 +1561,20 @@ export function AccountForm() {
                 <Switch
                   checked={hidePlatformLogos}
                   onCheckedChange={setHidePlatformLogos}
+                />
+              </div>
+            </div>
+
+            <div className="border-t border-border/10 pt-4 space-y-1">
+              <Label className="text-xs font-medium text-muted-foreground uppercase">Sync Options</Label>
+              <div className="flex items-center justify-between py-2">
+                <div>
+                  <p className="text-sm font-medium">Allow external addon management</p>
+                  <p className="text-xs text-muted-foreground">Sync addon changes made from connected apps directly to AIOManager.</p>
+                </div>
+                <Switch
+                  checked={allowExternalAddonManagement}
+                  onCheckedChange={setAllowExternalAddonManagement}
                 />
               </div>
             </div>

--- a/src/store/account/accountAddonOps.ts
+++ b/src/store/account/accountAddonOps.ts
@@ -204,7 +204,11 @@ export async function pushToConnections(accountId: string, options: { addons?: A
     }
 }
 
-function backgroundSync(accountId: string, account: Account, updatedAddons: AddonDescriptor[], options?: { allowCollectionShrink?: boolean }, trigger = 'unknown') {
+function backgroundSync(accountId: string, account: Account, updatedAddons: AddonDescriptor[], options?: { allowCollectionShrink?: boolean }, trigger = 'unknown', isAutopilot = false) {
+    if (account.allowExternalAddonManagement) {
+        import('./externalFailoverPush').then(m => m.backgroundSyncExternal(accountId, account, updatedAddons, options, trigger, isAutopilot)).catch(console.error)
+        return
+    }
     if (!hasPlatformConnection(account)) {
         return
     }
@@ -617,7 +621,7 @@ export async function toggleAddonEnabled(accountId: string, transportUrl: string
         persistAccounts(store.getState().accounts)
 
         if (!silent) {
-            backgroundSync(accountId, account, updatedAddons)
+            backgroundSync(accountId, account, updatedAddons, undefined, 'unknown', isAutopilot)
         }
 
         if (!isAutopilot) {

--- a/src/store/account/accountImportExport.ts
+++ b/src/store/account/accountImportExport.ts
@@ -143,6 +143,7 @@ async function buildExportData(includeCredentialsValue: boolean, forSync: boolea
             hideLastWatched: acc.hideLastWatched,
             hideAddonPreview: acc.hideAddonPreview,
             hidePlatformLogos: acc.hidePlatformLogos,
+            allowExternalAddonManagement: acc.allowExternalAddonManagement,
         }))
     )
 
@@ -459,6 +460,7 @@ export async function importAccounts(json: string, isSilent = false, mode: 'merg
                 hideLastWatched: acc.hideLastWatched as boolean | undefined,
                 hideAddonPreview: acc.hideAddonPreview as boolean | undefined,
                 hidePlatformLogos: acc.hidePlatformLogos as boolean | undefined,
+                allowExternalAddonManagement: acc.allowExternalAddonManagement as boolean | undefined,
                 apiKey: acc.apiKey as string | undefined,
                 createdAt: acc.createdAt as number | undefined,
                 lastSync: new Date(),
@@ -560,6 +562,7 @@ export async function importAccounts(json: string, isSilent = false, mode: 'merg
                     hideLastWatched: ra.hideLastWatched ?? matchedAccount.hideLastWatched,
                     hideAddonPreview: ra.hideAddonPreview ?? matchedAccount.hideAddonPreview,
                     hidePlatformLogos: ra.hidePlatformLogos ?? matchedAccount.hidePlatformLogos,
+                    allowExternalAddonManagement: ra.allowExternalAddonManagement ?? matchedAccount.allowExternalAddonManagement,
                     avatar: ra.avatar ?? matchedAccount.avatar,
                     apiKey: ra.apiKey ?? matchedAccount.apiKey ?? safeUUID(),
                     profiles: (() => {

--- a/src/store/account/accountImportExport.ts
+++ b/src/store/account/accountImportExport.ts
@@ -144,6 +144,8 @@ async function buildExportData(includeCredentialsValue: boolean, forSync: boolea
             hideAddonPreview: acc.hideAddonPreview,
             hidePlatformLogos: acc.hidePlatformLogos,
             allowExternalAddonManagement: acc.allowExternalAddonManagement,
+            sourceOfTruth: acc.sourceOfTruth,
+            protectedAddons: acc.protectedAddons,
         }))
     )
 
@@ -461,6 +463,8 @@ export async function importAccounts(json: string, isSilent = false, mode: 'merg
                 hideAddonPreview: acc.hideAddonPreview as boolean | undefined,
                 hidePlatformLogos: acc.hidePlatformLogos as boolean | undefined,
                 allowExternalAddonManagement: acc.allowExternalAddonManagement as boolean | undefined,
+                sourceOfTruth: acc.sourceOfTruth as string | undefined,
+                protectedAddons: acc.protectedAddons as string[] | undefined,
                 apiKey: acc.apiKey as string | undefined,
                 createdAt: acc.createdAt as number | undefined,
                 lastSync: new Date(),
@@ -563,6 +567,8 @@ export async function importAccounts(json: string, isSilent = false, mode: 'merg
                     hideAddonPreview: ra.hideAddonPreview ?? matchedAccount.hideAddonPreview,
                     hidePlatformLogos: ra.hidePlatformLogos ?? matchedAccount.hidePlatformLogos,
                     allowExternalAddonManagement: ra.allowExternalAddonManagement ?? matchedAccount.allowExternalAddonManagement,
+                    sourceOfTruth: ra.sourceOfTruth ?? matchedAccount.sourceOfTruth,
+                    protectedAddons: ra.protectedAddons ?? matchedAccount.protectedAddons,
                     avatar: ra.avatar ?? matchedAccount.avatar,
                     apiKey: ra.apiKey ?? matchedAccount.apiKey ?? safeUUID(),
                     profiles: (() => {

--- a/src/store/account/accountSync.ts
+++ b/src/store/account/accountSync.ts
@@ -243,6 +243,11 @@ async function syncAccountCore(id: string, forceRefresh: boolean): Promise<SyncC
     const account = getAccountById(store.getState().accounts, id)
     if (!account) throw new Error('Account not found')
 
+    if (account.allowExternalAddonManagement) {
+        const { syncExternalAddonManagement } = await import('./externalAddonSync')
+        return syncExternalAddonManagement(id, forceRefresh)
+    }
+
     const stremioConn = account.connections?.find(c => c.platform === 'stremio')
     const stremioEnabled = !account.connections?.length || stremioConn?.enabled !== false
     const accountAuthKey = getStremioAuthKey(account)

--- a/src/store/account/externalAddonSync.ts
+++ b/src/store/account/externalAddonSync.ts
@@ -210,9 +210,17 @@ export async function syncExternalAddonManagement(id: string, forceRefresh: bool
     const finalAddons = mergeWithReAnchoring(account.addons, sotAddons, protectedUrls)
     
     const { fingerprintAddonList } = await import('@/lib/addon-fingerprint')
-    const addonsChanged = fingerprintAddonList(account.addons) !== fingerprintAddonList(finalAddons)
+    const finalFingerprint = fingerprintAddonList(finalAddons)
+    const addonsChanged = fingerprintAddonList(account.addons) !== finalFingerprint
     
-    if (!addonsChanged) {
+    const sotFingerprint = fingerprintAddonList(sotAddons)
+    const sotUrlsSet = new Set(sotAddons.map(a => normalizeAddonUrl(a.transportUrl)))
+    const protectedAddonRestored = finalAddons.some(a => 
+        !sotUrlsSet.has(normalizeAddonUrl(a.transportUrl)) && 
+        (protectedUrls.has(normalizeAddonUrl(a.transportUrl)) || a.flags?.protected)
+    )
+    
+    if (!addonsChanged && !protectedAddonRestored) {
         return { changed: false, authKeyRefreshed: false }
     }
     
@@ -232,9 +240,7 @@ export async function syncExternalAddonManagement(id: string, forceRefresh: bool
     
     if (!useAuthStore.getState().encryptionKey) return { changed: true, authKeyRefreshed: false }
     
-    const finalFingerprint = fingerprintAddonList(finalAddons)
-    const sotFingerprint = fingerprintAddonList(sotAddons)
-    const needsSoTPush = finalFingerprint !== sotFingerprint
+    const needsSoTPush = finalFingerprint !== sotFingerprint || protectedAddonRestored
 
     const pushConnections = (updatedAccount.connections || []).filter(c => {
         if (!needsSoTPush) {

--- a/src/store/account/externalAddonSync.ts
+++ b/src/store/account/externalAddonSync.ts
@@ -178,9 +178,6 @@ export async function syncExternalAddonManagement(id: string, forceRefresh: bool
                 return { changed: false, authKeyRefreshed: false }
             }
             
-            const reFetchedUrls = new Set(reFetched.map(a => normalizeAddonUrl(a.transportUrl)))
-            const stillMissing = missingUrls.filter(url => !reFetchedUrls.has(url))
-            
             sotAddons.splice(0, sotAddons.length, ...reFetched)
         }
     }

--- a/src/store/account/externalAddonSync.ts
+++ b/src/store/account/externalAddonSync.ts
@@ -1,0 +1,238 @@
+﻿import { type Account } from '@/types/account'
+import { type Connection } from '@/types/connection'
+import { getStremioAuthKey, getCachedAuthKey, getEncryptionKey, getAccountById, persistAccounts, sanitizeAddonManifest } from '@/store/accountStore'
+import { getAddons } from '@/api/addons'
+import { fetchConnectionToken } from '@/api/connection'
+import { nuvioDriverFor, realStreamDriverFor } from '@/lib/drivers/factory'
+import type { AddonDescriptor } from '@/types/addon'
+import { normalizeAddonUrl } from '@/lib/utils'
+import { reconcileTombstones } from '@/lib/addon-tombstones'
+import { fetchAddonManifest } from '@/api/addons'
+import { getEffectiveManifest } from '@/lib/addon-utils'
+import type { AccountStore } from '@/store/accountStore'
+import { useAuthStore } from '@/store/authStore'
+
+type StoreRef = { getState: () => AccountStore; setState: (partial: Partial<AccountStore> | ((state: AccountStore) => Partial<AccountStore>)) => void }
+
+async function getStore(): Promise<StoreRef> {
+    const { useAccountStore } = await import('@/store/accountStore')
+    return useAccountStore
+}
+
+export type SoT = { type: 'stremio-native' } | { type: 'connection'; conn: Connection }
+
+export function determineSourceOfTruth(account: Account): SoT | null {
+    const nuvioConn = account.connections?.find(c => c.enabled && c.platform === 'nuvio')
+    if (nuvioConn) return { type: 'connection', conn: nuvioConn }
+    
+    const stremioConn = account.connections?.find(c => c.enabled && c.platform === 'stremio')
+    if (stremioConn) return { type: 'connection', conn: stremioConn }
+    
+    if (getStremioAuthKey(account)) return { type: 'stremio-native' }
+    
+    const otherConn = account.connections?.find(c => c.enabled)
+    if (otherConn) return { type: 'connection', conn: otherConn }
+    
+    return null
+}
+
+export async function fetchSoTAddons(account: Account, sot: SoT, forceRefresh: boolean): Promise<AddonDescriptor[]> {
+    if (sot.type === 'stremio-native' || (sot.type === 'connection' && sot.conn.platform === 'stremio')) {
+        const authKey = getStremioAuthKey(account)
+        if (!authKey) throw new Error('No Stremio auth key')
+        const decryptedKey = await getCachedAuthKey(authKey, getEncryptionKey())
+        return getAddons(decryptedKey, account.id, forceRefresh)
+    } else {
+        const conn = sot.conn
+        if (conn.platform === 'nuvio') {
+            const { getCachedNuvioToken, setCachedNuvioToken } = await import('@/lib/nuvio-token-cache')
+            let token = getCachedNuvioToken(conn.id)
+            if (!token) {
+                token = await fetchConnectionToken(account.id, conn.id, 'nuvio')
+                setCachedNuvioToken(conn.id, token)
+            }
+            const profileId = conn.credentials?.profileIndex || conn.credentials?.profileId
+            const rawAddons = await nuvioDriverFor(conn).readAddons(token.accessToken, profileId) as Record<string, unknown>[]
+            return rawAddons.map(r => ({
+                transportUrl: String(r.url || ''),
+                manifest: sanitizeAddonManifest({ name: String(r.name || '') } as any, String(r.url || '')),
+                flags: { enabled: r.enabled !== false }
+            })) as AddonDescriptor[]
+        } else if (conn.platform === 'realstream') {
+            const token = await fetchConnectionToken(account.id, conn.id, 'realstream')
+            const userId = conn.credentials?.userId || ''
+            const rawAddons = await realStreamDriverFor(conn).readAddons(token.accessToken, userId) as Record<string, unknown>[]
+            return rawAddons.map(r => ({
+                transportUrl: String(r.manifestUrl || r.baseUrl || ''),
+                manifest: sanitizeAddonManifest({ name: String(r.name || '') } as any, String(r.manifestUrl || r.baseUrl || '')),
+                flags: { enabled: r.enabled !== false }
+            })) as AddonDescriptor[]
+        }
+        throw new Error(Unsupported SoT platform: )
+    }
+}
+
+function mergeWithReAnchoring(localAddons: AddonDescriptor[], sotAddons: AddonDescriptor[]): AddonDescriptor[] {
+    const sotList = [...sotAddons]
+    const disabledAnchors = new Map<string, AddonDescriptor[]>()
+    let currentAnchor = ''
+
+    for (const a of localAddons) {
+        if (a.flags?.enabled === false) {
+            const list = disabledAnchors.get(currentAnchor) || []
+            list.push(a)
+            disabledAnchors.set(currentAnchor, list)
+        } else {
+            currentAnchor = normalizeAddonUrl(a.transportUrl)
+        }
+    }
+
+    const result: AddonDescriptor[] = []
+    
+    if (disabledAnchors.has('')) {
+        const toAdd = disabledAnchors.get('')!
+        for (const a of toAdd) {
+            if (!sotList.some(s => normalizeAddonUrl(s.transportUrl) === normalizeAddonUrl(a.transportUrl))) {
+                result.push(a)
+            }
+        }
+    }
+
+    for (const sa of sotList) {
+        const existingLocal = localAddons.find(l => normalizeAddonUrl(l.transportUrl) === normalizeAddonUrl(sa.transportUrl))
+        if (existingLocal) {
+             result.push({ ...existingLocal, flags: sa.flags })
+        } else {
+             result.push(sa)
+        }
+        
+        const anchorUrl = normalizeAddonUrl(sa.transportUrl)
+        if (disabledAnchors.has(anchorUrl)) {
+            const toAdd = disabledAnchors.get(anchorUrl)!
+            for (const a of toAdd) {
+                if (!sotList.some(s => normalizeAddonUrl(s.transportUrl) === normalizeAddonUrl(a.transportUrl))) {
+                    result.push(a)
+                }
+            }
+        }
+    }
+
+    return result
+}
+
+const phantomDebounceCache = new Map<string, { missingUrls: string[], timestamp: number }>()
+
+export async function syncExternalAddonManagement(id: string, forceRefresh: boolean): Promise<{ changed: boolean, authKeyRefreshed: boolean }> {
+    const store = await getStore()
+    const account = getAccountById(store.getState().accounts, id)
+    if (!account) throw new Error('Account not found')
+
+    const sot = determineSourceOfTruth(account)
+    if (!sot) {
+        return { changed: false, authKeyRefreshed: false }
+    }
+
+    const sotAddons = await fetchSoTAddons(account, sot, forceRefresh)
+    
+    if (sotAddons.length === 0) {
+        console.warn('[ExternalAddonSync] SoT returned empty list. Safeguard triggered, aborting sync.')
+        return { changed: false, authKeyRefreshed: false }
+    }
+
+    const localUrls = new Set(account.addons.map(a => normalizeAddonUrl(a.transportUrl)))
+    const sotUrls = new Set(sotAddons.map(a => normalizeAddonUrl(a.transportUrl)))
+
+    const missingUrls = [...localUrls].filter(url => !sotUrls.has(url))
+    
+    if (missingUrls.length > 0) {
+        const cache = phantomDebounceCache.get(id)
+        const now = Date.now()
+        if (!cache || (now - cache.timestamp > 5000)) {
+            phantomDebounceCache.set(id, { missingUrls, timestamp: now })
+            await new Promise(r => setTimeout(r, 5000))
+            const reFetched = await fetchSoTAddons(account, sot, forceRefresh)
+            if (reFetched.length === 0) {
+                return { changed: false, authKeyRefreshed: false }
+            }
+            
+            const reFetchedUrls = new Set(reFetched.map(a => normalizeAddonUrl(a.transportUrl)))
+            const stillMissing = missingUrls.filter(url => !reFetchedUrls.has(url))
+            
+            if (stillMissing.length === 0) {
+                sotAddons.splice(0, sotAddons.length, ...reFetched)
+            } else {
+                sotAddons.splice(0, sotAddons.length, ...reFetched)
+            }
+        }
+    }
+    
+    phantomDebounceCache.delete(id)
+    
+    // Fetch manifests for new addons
+    for (let i = 0; i < sotAddons.length; i++) {
+        if (!localUrls.has(normalizeAddonUrl(sotAddons[i].transportUrl))) {
+            try {
+                const { manifest } = await fetchAddonManifest(sotAddons[i].transportUrl, id)
+                sotAddons[i].manifest = sanitizeAddonManifest(manifest, sotAddons[i].transportUrl)
+                sotAddons[i] = { ...sotAddons[i], manifest: getEffectiveManifest(sotAddons[i]) }
+            } catch (e) {
+                console.warn('[ExternalAddonSync] Failed to fetch manifest for new addon', e)
+            }
+        }
+    }
+    
+    const finalAddons = mergeWithReAnchoring(account.addons, sotAddons)
+    
+    const { fingerprintAddonList } = await import('@/lib/addon-fingerprint')
+    const addonsChanged = fingerprintAddonList(account.addons) !== fingerprintAddonList(finalAddons)
+    
+    if (!addonsChanged) {
+        return { changed: false, authKeyRefreshed: false }
+    }
+    
+    const updatedAccount = {
+        ...account,
+        addons: finalAddons,
+        deletedAddons: reconcileTombstones(account.deletedAddons, finalAddons),
+        lastSync: new Date()
+    }
+    
+    const accounts = store.getState().accounts.map((acc) => (acc.id === id ? updatedAccount : acc))
+    store.setState({ accounts })
+    persistAccounts(accounts)
+    
+    const { useAddonStore } = await import('@/store/addonStore')
+    await useAddonStore.getState().syncAccountState(id, getStremioAuthKey(updatedAccount), finalAddons).catch(e => { console.error(e) })
+    
+    if (!useAuthStore.getState().encryptionKey) return { changed: true, authKeyRefreshed: false }
+    
+    const pushConnections = (updatedAccount.connections || []).filter(c => {
+        if (sot.type === 'connection' && c.id === sot.conn.id) return false
+        if (sot.type === 'stremio-native' && c.platform === 'stremio') return false
+        return c.enabled
+    })
+    
+    const { triggerReconciliation } = await import('@/api/connection')
+    if (pushConnections.length > 0) {
+        try {
+            await triggerReconciliation(id, updatedAccount.primaryConnectionId, pushConnections, finalAddons)
+        } catch (e) {
+            console.warn('[ExternalAddonSync] Push to other connections failed', e)
+        }
+    }
+    
+    if (sot.type !== 'stremio-native' && !(sot.type === 'connection' && sot.conn.platform === 'stremio')) {
+        const stremioKey = getStremioAuthKey(updatedAccount)
+        if (stremioKey) {
+            try {
+                const { updateAddons } = await import('@/api/addons')
+                const decryptedKey = await getCachedAuthKey(stremioKey, getEncryptionKey())
+                await updateAddons(decryptedKey, finalAddons, id, { previousCollection: account.addons })
+            } catch (e) {
+                console.warn('[ExternalAddonSync] Push to Stremio failed', e)
+            }
+        }
+    }
+    
+    return { changed: true, authKeyRefreshed: false }
+}

--- a/src/store/account/externalAddonSync.ts
+++ b/src/store/account/externalAddonSync.ts
@@ -1,4 +1,4 @@
-﻿import { type Account } from '@/types/account'
+import { type Account } from '@/types/account'
 import { type Connection } from '@/types/connection'
 import { getStremioAuthKey, getCachedAuthKey, getEncryptionKey, getAccountById, persistAccounts, sanitizeAddonManifest } from '@/store/accountStore'
 import { getAddons } from '@/api/addons'
@@ -68,7 +68,7 @@ export async function fetchSoTAddons(account: Account, sot: SoT, forceRefresh: b
                 flags: { enabled: r.enabled !== false }
             })) as AddonDescriptor[]
         }
-        throw new Error(Unsupported SoT platform: )
+        throw new Error(`Unsupported SoT platform: ${(conn as Connection).platform}`)
     }
 }
 

--- a/src/store/account/externalAddonSync.ts
+++ b/src/store/account/externalAddonSync.ts
@@ -85,7 +85,7 @@ function mergeWithReAnchoring(localAddons: AddonDescriptor[], sotAddons: AddonDe
 
     for (const a of localAddons) {
         const url = normalizeAddonUrl(a.transportUrl)
-        const isProtected = protectedUrls.has(url)
+        const isProtected = protectedUrls.has(url) || a.flags?.protected
         const isMissingFromSoT = !sotList.some(s => normalizeAddonUrl(s.transportUrl) === url)
 
         if (isMissingFromSoT && (a.flags?.enabled === false || isProtected)) {
@@ -112,7 +112,16 @@ function mergeWithReAnchoring(localAddons: AddonDescriptor[], sotAddons: AddonDe
     for (const sa of sotList) {
         const existingLocal = localAddons.find(l => normalizeAddonUrl(l.transportUrl) === normalizeAddonUrl(sa.transportUrl))
         if (existingLocal) {
-             result.push({ ...existingLocal, flags: sa.flags })
+             // Cache Local State & Merge & Restore:
+             // Preserve aiomanager-specific metadata (specifically the protected boolean flag)
+             result.push({ 
+                 ...existingLocal, 
+                 flags: { 
+                     ...existingLocal.flags,
+                     ...sa.flags,
+                     protected: existingLocal.flags?.protected 
+                 } 
+             })
         } else {
              result.push(sa)
         }

--- a/src/store/account/externalAddonSync.ts
+++ b/src/store/account/externalAddonSync.ts
@@ -22,6 +22,12 @@ async function getStore(): Promise<StoreRef> {
 export type SoT = { type: 'stremio-native' } | { type: 'connection'; conn: Connection }
 
 export function determineSourceOfTruth(account: Account): SoT | null {
+    if (account.sourceOfTruth) {
+        if (account.sourceOfTruth === 'stremio-native' && getStremioAuthKey(account)) return { type: 'stremio-native' }
+        const conn = account.connections?.find(c => c.enabled && c.id === account.sourceOfTruth)
+        if (conn) return { type: 'connection', conn }
+    }
+
     const nuvioConn = account.connections?.find(c => c.enabled && c.platform === 'nuvio')
     if (nuvioConn) return { type: 'connection', conn: nuvioConn }
     
@@ -72,27 +78,32 @@ export async function fetchSoTAddons(account: Account, sot: SoT, forceRefresh: b
     }
 }
 
-function mergeWithReAnchoring(localAddons: AddonDescriptor[], sotAddons: AddonDescriptor[]): AddonDescriptor[] {
+function mergeWithReAnchoring(localAddons: AddonDescriptor[], sotAddons: AddonDescriptor[], protectedUrls: Set<string>): AddonDescriptor[] {
     const sotList = [...sotAddons]
-    const disabledAnchors = new Map<string, AddonDescriptor[]>()
+    const anchoredAddons = new Map<string, AddonDescriptor[]>()
     let currentAnchor = ''
 
     for (const a of localAddons) {
-        if (a.flags?.enabled === false) {
-            const list = disabledAnchors.get(currentAnchor) || []
+        const url = normalizeAddonUrl(a.transportUrl)
+        const isProtected = protectedUrls.has(url)
+        const isMissingFromSoT = !sotList.some(s => normalizeAddonUrl(s.transportUrl) === url)
+
+        if (isMissingFromSoT && (a.flags?.enabled === false || isProtected)) {
+            const list = anchoredAddons.get(currentAnchor) || []
             list.push(a)
-            disabledAnchors.set(currentAnchor, list)
-        } else {
-            currentAnchor = normalizeAddonUrl(a.transportUrl)
+            anchoredAddons.set(currentAnchor, list)
+        } else if (!isMissingFromSoT) {
+            currentAnchor = url
         }
     }
 
     const result: AddonDescriptor[] = []
     
-    if (disabledAnchors.has('')) {
-        const toAdd = disabledAnchors.get('')!
+    if (anchoredAddons.has('')) {
+        const toAdd = anchoredAddons.get('')!
         for (const a of toAdd) {
-            if (!sotList.some(s => normalizeAddonUrl(s.transportUrl) === normalizeAddonUrl(a.transportUrl))) {
+            if (!result.some(s => normalizeAddonUrl(s.transportUrl) === normalizeAddonUrl(a.transportUrl)) &&
+                !sotList.some(s => normalizeAddonUrl(s.transportUrl) === normalizeAddonUrl(a.transportUrl))) {
                 result.push(a)
             }
         }
@@ -107,10 +118,11 @@ function mergeWithReAnchoring(localAddons: AddonDescriptor[], sotAddons: AddonDe
         }
         
         const anchorUrl = normalizeAddonUrl(sa.transportUrl)
-        if (disabledAnchors.has(anchorUrl)) {
-            const toAdd = disabledAnchors.get(anchorUrl)!
+        if (anchoredAddons.has(anchorUrl)) {
+            const toAdd = anchoredAddons.get(anchorUrl)!
             for (const a of toAdd) {
-                if (!sotList.some(s => normalizeAddonUrl(s.transportUrl) === normalizeAddonUrl(a.transportUrl))) {
+                if (!result.some(s => normalizeAddonUrl(s.transportUrl) === normalizeAddonUrl(a.transportUrl)) &&
+                    !sotList.some(s => normalizeAddonUrl(s.transportUrl) === normalizeAddonUrl(a.transportUrl))) {
                     result.push(a)
                 }
             }
@@ -122,7 +134,7 @@ function mergeWithReAnchoring(localAddons: AddonDescriptor[], sotAddons: AddonDe
 
 const phantomDebounceCache = new Map<string, { missingUrls: string[], timestamp: number }>()
 
-export async function syncExternalAddonManagement(id: string, forceRefresh: boolean): Promise<{ changed: boolean, authKeyRefreshed: boolean }> {
+export async function syncExternalAddonManagement(id: string, forceRefresh: boolean, pollStartTime: number = Date.now()): Promise<{ changed: boolean, authKeyRefreshed: boolean }> {
     const store = await getStore()
     const account = getAccountById(store.getState().accounts, id)
     if (!account) throw new Error('Account not found')
@@ -134,8 +146,15 @@ export async function syncExternalAddonManagement(id: string, forceRefresh: bool
 
     const sotAddons = await fetchSoTAddons(account, sot, forceRefresh)
     
+    const nowMs = Date.now()
+    const elapsed = nowMs - pollStartTime
+    const nextPollDelay = elapsed < 120_000 ? 10_000 : 60_000
+
     if (sotAddons.length === 0) {
-        console.warn('[ExternalAddonSync] SoT returned empty list. Safeguard triggered, aborting sync.')
+        console.warn(`[ExternalAddonSync] SoT returned empty list. Safeguard triggered, aborting sync. Next poll in ${nextPollDelay/1000}s.`)
+        setTimeout(() => {
+            syncExternalAddonManagement(id, forceRefresh, pollStartTime).catch(e => console.error(e))
+        }, nextPollDelay)
         return { changed: false, authKeyRefreshed: false }
     }
 
@@ -152,17 +171,17 @@ export async function syncExternalAddonManagement(id: string, forceRefresh: bool
             await new Promise(r => setTimeout(r, 5000))
             const reFetched = await fetchSoTAddons(account, sot, forceRefresh)
             if (reFetched.length === 0) {
+                console.warn(`[ExternalAddonSync] SoT returned empty list during re-fetch. Safeguard triggered. Next poll in ${nextPollDelay/1000}s.`)
+                setTimeout(() => {
+                    syncExternalAddonManagement(id, forceRefresh, pollStartTime).catch(e => console.error(e))
+                }, nextPollDelay)
                 return { changed: false, authKeyRefreshed: false }
             }
             
             const reFetchedUrls = new Set(reFetched.map(a => normalizeAddonUrl(a.transportUrl)))
             const stillMissing = missingUrls.filter(url => !reFetchedUrls.has(url))
             
-            if (stillMissing.length === 0) {
-                sotAddons.splice(0, sotAddons.length, ...reFetched)
-            } else {
-                sotAddons.splice(0, sotAddons.length, ...reFetched)
-            }
+            sotAddons.splice(0, sotAddons.length, ...reFetched)
         }
     }
     
@@ -181,7 +200,8 @@ export async function syncExternalAddonManagement(id: string, forceRefresh: bool
         }
     }
     
-    const finalAddons = mergeWithReAnchoring(account.addons, sotAddons)
+    const protectedUrls = new Set((account.protectedAddons || []).map(normalizeAddonUrl))
+    const finalAddons = mergeWithReAnchoring(account.addons, sotAddons, protectedUrls)
     
     const { fingerprintAddonList } = await import('@/lib/addon-fingerprint')
     const addonsChanged = fingerprintAddonList(account.addons) !== fingerprintAddonList(finalAddons)
@@ -206,9 +226,15 @@ export async function syncExternalAddonManagement(id: string, forceRefresh: bool
     
     if (!useAuthStore.getState().encryptionKey) return { changed: true, authKeyRefreshed: false }
     
+    const finalFingerprint = fingerprintAddonList(finalAddons)
+    const sotFingerprint = fingerprintAddonList(sotAddons)
+    const needsSoTPush = finalFingerprint !== sotFingerprint
+
     const pushConnections = (updatedAccount.connections || []).filter(c => {
-        if (sot.type === 'connection' && c.id === sot.conn.id) return false
-        if (sot.type === 'stremio-native' && c.platform === 'stremio') return false
+        if (!needsSoTPush) {
+            if (sot.type === 'connection' && c.id === sot.conn.id) return false
+            if (sot.type === 'stremio-native' && c.platform === 'stremio') return false
+        }
         return c.enabled
     })
     
@@ -221,16 +247,17 @@ export async function syncExternalAddonManagement(id: string, forceRefresh: bool
         }
     }
     
-    if (sot.type !== 'stremio-native' && !(sot.type === 'connection' && sot.conn.platform === 'stremio')) {
-        const stremioKey = getStremioAuthKey(updatedAccount)
-        if (stremioKey) {
-            try {
-                const { updateAddons } = await import('@/api/addons')
-                const decryptedKey = await getCachedAuthKey(stremioKey, getEncryptionKey())
-                await updateAddons(decryptedKey, finalAddons, id, { previousCollection: account.addons })
-            } catch (e) {
-                console.warn('[ExternalAddonSync] Push to Stremio failed', e)
-            }
+    const stremioKey = getStremioAuthKey(updatedAccount)
+    const shouldPushStremio = stremioKey && (
+        needsSoTPush || (sot.type !== 'stremio-native' && !(sot.type === 'connection' && sot.conn.platform === 'stremio'))
+    )
+    if (shouldPushStremio) {
+        try {
+            const { updateAddons } = await import('@/api/addons')
+            const decryptedKey = await getCachedAuthKey(stremioKey, getEncryptionKey())
+            await updateAddons(decryptedKey, finalAddons, id, { previousCollection: account.addons })
+        } catch (e) {
+            console.warn('[ExternalAddonSync] Push to Stremio failed', e)
         }
     }
     

--- a/src/store/account/externalFailoverPush.ts
+++ b/src/store/account/externalFailoverPush.ts
@@ -61,18 +61,17 @@ export async function backgroundSyncExternal(
     // Push updatedAddons to ALL connections (including SoT)
     const promises: Promise<void>[] = []
 
-    const pushConnections = (account.connections || []).filter(c => c.enabled)
-    const { triggerReconciliation } = await import('@/api/connection')
-    if (pushConnections.length > 0) {
-        promises.push(
-            triggerReconciliation(accountId, account.primaryConnectionId, pushConnections, updatedAddons, {
-                allowCollectionShrink: options?.allowCollectionShrink
-            }).then(() => {}).catch(console.error)
-        )
-    }
+    const { pushToConnections } = await import('./accountAddonOps')
+    promises.push(
+        pushToConnections(accountId, { addons: updatedAddons, allowCollectionShrink: options?.allowCollectionShrink })
+            .catch(err => console.error('[ExternalFailoverPush] Failed to push to connections:', err))
+    )
 
     const stremioKey = getStremioAuthKey(account)
-    if (stremioKey) {
+    const stremioConn = account.connections?.find(c => c.platform === 'stremio')
+    const stremioPushEnabled = !stremioConn || stremioConn.enabled !== false
+
+    if (stremioKey && stremioPushEnabled) {
         const { updateAddons } = await import('@/api/addons')
         promises.push(
             getCachedAuthKey(stremioKey, getEncryptionKey())

--- a/src/store/account/externalFailoverPush.ts
+++ b/src/store/account/externalFailoverPush.ts
@@ -1,24 +1,18 @@
-﻿import { type Account } from '@/types/account'
-import { getAccountById, persistAccounts } from '@/store/accountStore'
+import { type Account } from '@/types/account'
 import { determineSourceOfTruth, fetchSoTAddons } from './externalAddonSync'
 import { normalizeAddonUrl } from '@/lib/utils'
 import type { AddonDescriptor } from '@/types/addon'
 import { triggerSync } from '@/lib/sync-trigger'
 import { getStremioAuthKey, getCachedAuthKey, getEncryptionKey } from '@/store/accountStore'
-import { reconcileTombstones } from '@/lib/addon-tombstones'
-import type { AccountStore } from '@/store/accountStore'
-import { useAuthStore } from '@/store/authStore'
 
-type StoreRef = { getState: () => AccountStore; setState: (partial: Partial<AccountStore> | ((state: AccountStore) => Partial<AccountStore>)) => void }
-
-async function getStore(): Promise<StoreRef> {
-    const { useAccountStore } = await import('@/store/accountStore')
-    return useAccountStore
-}
-
-export async function backgroundSyncExternal(accountId: string, account: Account, updatedAddons: AddonDescriptor[], options?: { allowCollectionShrink?: boolean }, trigger = 'unknown', isAutopilot = false) {
-    const store = await getStore()
-
+export async function backgroundSyncExternal(
+    accountId: string,
+    account: Account,
+    updatedAddons: AddonDescriptor[],
+    options?: { allowCollectionShrink?: boolean },
+    _trigger = 'unknown',
+    isAutopilot = false
+) {
     if (isAutopilot) {
         // JIT Fetch-Patch-Push strategy
         const sot = determineSourceOfTruth(account)
@@ -51,12 +45,9 @@ export async function backgroundSyncExternal(accountId: string, account: Account
                     return sa
                 })
                 
-                updatedAddons = finalSotAddons
-                
-                // Wait, if autopilot turned ON an addon, and it wasn't in sotAddons?
+                // If autopilot turned ON an addon and it wasn't in sotAddons
                 for (const [url, addon] of changedUrls.entries()) {
                     if (!finalSotAddons.some(sa => normalizeAddonUrl(sa.transportUrl) === url)) {
-                        // Insert using anchor? For autopilot it just enables/disables. If it enables an addon not in SoT, just push it.
                         finalSotAddons.push(addon)
                     }
                 }
@@ -67,15 +58,17 @@ export async function backgroundSyncExternal(accountId: string, account: Account
         }
     }
 
-    // Now push updatedAddons to ALL connections (including SoT!)
+    // Push updatedAddons to ALL connections (including SoT)
     const promises: Promise<void>[] = []
-    
-    const sot = determineSourceOfTruth(account)
 
     const pushConnections = (account.connections || []).filter(c => c.enabled)
     const { triggerReconciliation } = await import('@/api/connection')
     if (pushConnections.length > 0) {
-        promises.push(triggerReconciliation(accountId, account.primaryConnectionId, pushConnections, updatedAddons).then(() => {}).catch(console.error))
+        promises.push(
+            triggerReconciliation(accountId, account.primaryConnectionId, pushConnections, updatedAddons, {
+                allowCollectionShrink: options?.allowCollectionShrink
+            }).then(() => {}).catch(console.error)
+        )
     }
 
     const stremioKey = getStremioAuthKey(account)
@@ -83,7 +76,10 @@ export async function backgroundSyncExternal(accountId: string, account: Account
         const { updateAddons } = await import('@/api/addons')
         promises.push(
             getCachedAuthKey(stremioKey, getEncryptionKey())
-                .then(decryptedKey => updateAddons(decryptedKey, updatedAddons, accountId, { previousCollection: account.addons }))
+                .then(decryptedKey => updateAddons(decryptedKey, updatedAddons, accountId, {
+                    previousCollection: account.addons,
+                    allowCollectionShrink: options?.allowCollectionShrink
+                }))
                 .catch(console.error)
         )
     }

--- a/src/store/account/externalFailoverPush.ts
+++ b/src/store/account/externalFailoverPush.ts
@@ -1,0 +1,94 @@
+﻿import { type Account } from '@/types/account'
+import { getAccountById, persistAccounts } from '@/store/accountStore'
+import { determineSourceOfTruth, fetchSoTAddons } from './externalAddonSync'
+import { normalizeAddonUrl } from '@/lib/utils'
+import type { AddonDescriptor } from '@/types/addon'
+import { triggerSync } from '@/lib/sync-trigger'
+import { getStremioAuthKey, getCachedAuthKey, getEncryptionKey } from '@/store/accountStore'
+import { reconcileTombstones } from '@/lib/addon-tombstones'
+import type { AccountStore } from '@/store/accountStore'
+import { useAuthStore } from '@/store/authStore'
+
+type StoreRef = { getState: () => AccountStore; setState: (partial: Partial<AccountStore> | ((state: AccountStore) => Partial<AccountStore>)) => void }
+
+async function getStore(): Promise<StoreRef> {
+    const { useAccountStore } = await import('@/store/accountStore')
+    return useAccountStore
+}
+
+export async function backgroundSyncExternal(accountId: string, account: Account, updatedAddons: AddonDescriptor[], options?: { allowCollectionShrink?: boolean }, trigger = 'unknown', isAutopilot = false) {
+    const store = await getStore()
+
+    if (isAutopilot) {
+        // JIT Fetch-Patch-Push strategy
+        const sot = determineSourceOfTruth(account)
+        if (sot) {
+            try {
+                const sotAddons = await fetchSoTAddons(account, sot, true)
+                // Patch the missing/added ones based on updatedAddons
+                
+                // We know 'updatedAddons' is the AIOManager list after the autopilot toggle.
+                // We just need to find the diff (the addon that was toggled) and apply it to 'sotAddons'.
+                
+                const before = account.addons
+                const after = updatedAddons
+                
+                // Find what changed
+                const changedUrls = new Map<string, AddonDescriptor>()
+                for (const a of after) {
+                    const b = before.find(x => normalizeAddonUrl(x.transportUrl) === normalizeAddonUrl(a.transportUrl))
+                    if (!b || b.flags?.enabled !== a.flags?.enabled) {
+                        changedUrls.set(normalizeAddonUrl(a.transportUrl), a)
+                    }
+                }
+                
+                // Patch sotAddons
+                const finalSotAddons = sotAddons.map(sa => {
+                    const changed = changedUrls.get(normalizeAddonUrl(sa.transportUrl))
+                    if (changed) {
+                        return { ...sa, flags: changed.flags }
+                    }
+                    return sa
+                })
+                
+                updatedAddons = finalSotAddons
+                
+                // Wait, if autopilot turned ON an addon, and it wasn't in sotAddons?
+                for (const [url, addon] of changedUrls.entries()) {
+                    if (!finalSotAddons.some(sa => normalizeAddonUrl(sa.transportUrl) === url)) {
+                        // Insert using anchor? For autopilot it just enables/disables. If it enables an addon not in SoT, just push it.
+                        finalSotAddons.push(addon)
+                    }
+                }
+                updatedAddons = finalSotAddons
+            } catch (e) {
+                console.warn('[ExternalFailoverPush] JIT fetch failed, falling back to pushing local state', e)
+            }
+        }
+    }
+
+    // Now push updatedAddons to ALL connections (including SoT!)
+    const promises: Promise<void>[] = []
+    
+    const sot = determineSourceOfTruth(account)
+
+    const pushConnections = (account.connections || []).filter(c => c.enabled)
+    const { triggerReconciliation } = await import('@/api/connection')
+    if (pushConnections.length > 0) {
+        promises.push(triggerReconciliation(accountId, account.primaryConnectionId, pushConnections, updatedAddons).then(() => {}).catch(console.error))
+    }
+
+    const stremioKey = getStremioAuthKey(account)
+    if (stremioKey) {
+        const { updateAddons } = await import('@/api/addons')
+        promises.push(
+            getCachedAuthKey(stremioKey, getEncryptionKey())
+                .then(decryptedKey => updateAddons(decryptedKey, updatedAddons, accountId, { previousCollection: account.addons }))
+                .catch(console.error)
+        )
+    }
+
+    await Promise.all(promises)
+
+    triggerSync()
+}

--- a/src/store/accountStore.ts
+++ b/src/store/accountStore.ts
@@ -354,7 +354,7 @@ export interface AccountStore {
       importAccounts: (json: string, isSilent?: boolean, mode?: 'merge' | 'mirror', localDecryptionKey?: CryptoKey | null) => Promise<void>
       updateAccount: (
             id: string,
-            data: { name?: string; authKey?: string; email?: string; password?: string; accentColor?: string; emoji?: string; avatar?: string; note?: string; hideLastWatched?: boolean; hideAddonPreview?: boolean; hidePlatformLogos?: boolean; allowExternalAddonManagement?: boolean }
+            data: { name?: string; authKey?: string; email?: string; password?: string; accentColor?: string; emoji?: string; avatar?: string; note?: string; hideLastWatched?: boolean; hideAddonPreview?: boolean; hidePlatformLogos?: boolean; allowExternalAddonManagement?: boolean; sourceOfTruth?: string }
       ) => Promise<void>
       updateAccountNote: (accountId: string, note: string) => Promise<void>
       toggleAddonProtection: (
@@ -927,7 +927,7 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
             return importAccounts(json, isSilent, mode, localDecryptionKey)
       },
 
-      updateAccount: async (id: string, data: { name?: string; authKey?: string; email?: string; password?: string; accentColor?: string; emoji?: string; avatar?: string; note?: string; hideLastWatched?: boolean; hideAddonPreview?: boolean; hidePlatformLogos?: boolean; allowExternalAddonManagement?: boolean }) => {
+      updateAccount: async (id: string, data: { name?: string; authKey?: string; email?: string; password?: string; accentColor?: string; emoji?: string; avatar?: string; note?: string; hideLastWatched?: boolean; hideAddonPreview?: boolean; hidePlatformLogos?: boolean; allowExternalAddonManagement?: boolean; sourceOfTruth?: string }) => {
             // The re-auth branch awaits (login + getAddons) then writes a snapshot taken before the
             // await, which would clobber any addon op that landed meanwhile. Hold the per-account
             // mutex so this serializes with addon writes instead of racing them.
@@ -950,6 +950,7 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
                         hideAddonPreview: data.hideAddonPreview !== undefined ? data.hideAddonPreview : (account.hideAddonPreview ?? false),
                         hidePlatformLogos: data.hidePlatformLogos !== undefined ? data.hidePlatformLogos : (account.hidePlatformLogos ?? false),
                         allowExternalAddonManagement: data.allowExternalAddonManagement !== undefined ? data.allowExternalAddonManagement : (account.allowExternalAddonManagement ?? false),
+                        sourceOfTruth: 'sourceOfTruth' in data ? data.sourceOfTruth : account.sourceOfTruth,
                   }
                   if (data.authKey || (data.email && data.password)) {
                         const encryptionKey = getEncryptionKey()

--- a/src/store/accountStore.ts
+++ b/src/store/accountStore.ts
@@ -354,7 +354,7 @@ export interface AccountStore {
       importAccounts: (json: string, isSilent?: boolean, mode?: 'merge' | 'mirror', localDecryptionKey?: CryptoKey | null) => Promise<void>
       updateAccount: (
             id: string,
-            data: { name: string; authKey?: string; email?: string; password?: string; accentColor?: string; emoji?: string; avatar?: string; note?: string; hideLastWatched?: boolean; hideAddonPreview?: boolean; hidePlatformLogos?: boolean }
+            data: { name?: string; authKey?: string; email?: string; password?: string; accentColor?: string; emoji?: string; avatar?: string; note?: string; hideLastWatched?: boolean; hideAddonPreview?: boolean; hidePlatformLogos?: boolean; allowExternalAddonManagement?: boolean }
       ) => Promise<void>
       updateAccountNote: (accountId: string, note: string) => Promise<void>
       toggleAddonProtection: (
@@ -927,7 +927,7 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
             return importAccounts(json, isSilent, mode, localDecryptionKey)
       },
 
-      updateAccount: async (id: string, data: { name: string; authKey?: string; email?: string; password?: string; accentColor?: string; emoji?: string; avatar?: string; note?: string; hideLastWatched?: boolean; hideAddonPreview?: boolean; hidePlatformLogos?: boolean }) => {
+      updateAccount: async (id: string, data: { name?: string; authKey?: string; email?: string; password?: string; accentColor?: string; emoji?: string; avatar?: string; note?: string; hideLastWatched?: boolean; hideAddonPreview?: boolean; hidePlatformLogos?: boolean; allowExternalAddonManagement?: boolean }) => {
             // The re-auth branch awaits (login + getAddons) then writes a snapshot taken before the
             // await, which would clobber any addon op that landed meanwhile. Hold the per-account
             // mutex so this serializes with addon writes instead of racing them.
@@ -941,14 +941,15 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
 
                   const updatedAccount: Account = {
                         ...account,
-                        name: data.name,
-                        accentColor: data.accentColor,
-                        emoji: data.emoji,
+                        name: data.name !== undefined ? data.name : account.name,
+                        accentColor: data.accentColor !== undefined ? data.accentColor : account.accentColor,
+                        emoji: data.emoji !== undefined ? data.emoji : account.emoji,
                         avatar: 'avatar' in data ? data.avatar : account.avatar,
-                        note: data.note || undefined,
-                        hideLastWatched: data.hideLastWatched ?? false,
-                        hideAddonPreview: data.hideAddonPreview ?? false,
-                        hidePlatformLogos: data.hidePlatformLogos ?? false,
+                        note: data.note !== undefined ? (data.note || undefined) : account.note,
+                        hideLastWatched: data.hideLastWatched !== undefined ? data.hideLastWatched : (account.hideLastWatched ?? false),
+                        hideAddonPreview: data.hideAddonPreview !== undefined ? data.hideAddonPreview : (account.hideAddonPreview ?? false),
+                        hidePlatformLogos: data.hidePlatformLogos !== undefined ? data.hidePlatformLogos : (account.hidePlatformLogos ?? false),
+                        allowExternalAddonManagement: data.allowExternalAddonManagement !== undefined ? data.allowExternalAddonManagement : (account.allowExternalAddonManagement ?? false),
                   }
                   if (data.authKey || (data.email && data.password)) {
                         const encryptionKey = getEncryptionKey()

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -33,6 +33,8 @@ export interface Account {
   hideAddonPreview?: boolean
   hidePlatformLogos?: boolean
   allowExternalAddonManagement?: boolean
+  sourceOfTruth?: string
+  protectedAddons?: string[]
   profiles?: AccountProfile[]
   activeProfileId?: string
   connections?: Connection[]

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -32,6 +32,7 @@ export interface Account {
   hideLastWatched?: boolean
   hideAddonPreview?: boolean
   hidePlatformLogos?: boolean
+  allowExternalAddonManagement?: boolean
   profiles?: AccountProfile[]
   activeProfileId?: string
   connections?: Connection[]


### PR DESCRIPTION
New "allow external addon management" can be toggled on from the account editing modal. It allows users to designate a specific client as the Source of Truth (SoT) for their addon list. To avoid polluting legacy logic, this feature runs through a completely separated pipeline and is disabled by default. The primary motivation behind this feature is compatibility with the Bingecat addon and any others that automatically push new manifests by remotely removing and readding the addon.

### Key Features
Configurable SoT
- Added a new "Source of Truth App" option in account editing modal.
- Defaults to nuvio -> stremio -> other connected accounts if not manually set.

Strict Sync Directionality
- Listens for addon changes on the SoT and syncs them to dashboard and other connected clients.
- Never pushes changes back to the SoT unless a manual change is made locally in aiomanager (with one specific exception for Protected Addons, detailed below).

Disabled Addon Anchoring
- Implemented an anchor strategy for disabled addons (which are invisible to the SoT). They are now indexed relative to the ID of their preceding active addon, ensuring they shift correctly if new addons are installed remotely.


### Resilience & Edge Case Handling
- Empty List Safeguard (Outage Protection): If the SoT returns an empty list (length 0), the pipeline halts immediately. This prevents a temporary API outage on the remote client from wiping out the user's entire setup.
- Phantom Removal Debouncing: If an addon suddenly disappears from the SoT, the system waits 5 seconds and re-fetches to confirm the deletion before propagating it to other clients.
- Autopilot Failover (JIT Fetch-Patch-Push): During a failover event, the system performs a Just-In-Time fetch of the live SoT list, patches the failed addon with its replacement at the correct anchor index in memory, and pushes the delta. This guarantees we never push a stale local list that would overwrite recent remote user changes.
-Protected Addon Restoration: If a remote sync attempts to remove an addon flagged locally as protected, aiomanager intercepts the sync, restores the addon using its anchor index, and saves it.


### Testing
- The new mode has been tested for ~24hrs with no major issues. This was tested with nuvio as the only connected service, therefore propogation from the SoT service to others has not been verified.
- Both pushing changes from the aiomanager dashboard and detecting changing in the client app have been tested.
- Autopilot failover has been tested.