### PR TITLE
ci: build each arch on a native runner instead of emulating arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,11 +26,22 @@ jobs:
       - run: npm run typecheck
 
   build:
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     needs: [client-gate]
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: Checkout repository
@@ -51,8 +62,90 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.6.0
+      # ghcr rejects an uppercase path and github.repository preserves the
+      # owner's casing, so the name is lowered before it reaches a ref.
+      - name: Compute the ghcr image name
+        id: img
+        run: echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.11.1
+
+      # Pull requests build as a check and publish nothing, so they stop here
+      # rather than pushing a digest with no manifest to point at it.
+      - name: Build (pull request check)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          pull: true
+          push: false
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Build and push by digest
+        id: build
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          pull: true
+          # One registry only. Pushing by digest to two produces a different
+          # digest in each, and buildx reports one of them, so the merge job can
+          # be handed a digest the registry it asks does not hold. Docker Hub is
+          # filled from the finished manifest in the merge job instead.
+          outputs: |
+            type=image,name=${{ env.REGISTRY }}/${{ steps.img.outputs.name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      # The digest names this arch's image in the registry it was pushed to.
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.5.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3.5.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
@@ -71,14 +164,39 @@ jobs:
             type=semver,pattern={{version}}
             type=sha
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6.18.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          pull: true
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # The digests name images in GHCR, so the manifest is assembled there.
+      - name: Create manifest list and push to GHCR
+        id: ghcr
+        working-directory: /tmp/digests
+        run: |
+          image="${REGISTRY}/${IMAGE_NAME,,}"
+          tag_args=()
+          first=""
+          while read -r tag; do
+            [ -n "$tag" ] || continue
+            case "$tag" in
+              "${image}:"*)
+                tag_args+=(-t "$tag")
+                [ -n "$first" ] || first="$tag"
+                ;;
+            esac
+          done <<< '${{ steps.meta.outputs.tags }}'
+          [ ${#tag_args[@]} -gt 0 ] || { echo "no GHCR tags to push"; exit 1; }
+          docker buildx imagetools create "${tag_args[@]}" \
+            $(printf "${image}@sha256:%s " *)
+          echo "source=${first}" >> "$GITHUB_OUTPUT"
+
+      # Copied from the finished GHCR manifest rather than rebuilt from the
+      # digests: a digest identifies an image within one registry, so the ones
+      # above cannot be resolved here.
+      - name: Copy the manifest to Docker Hub
+        run: |
+          tag_args=()
+          while read -r tag; do
+            [ -n "$tag" ] || continue
+            case "$tag" in
+              "${DOCKER_HUB_IMAGE}:"*) tag_args+=(-t "$tag") ;;
+            esac
+          done <<< '${{ steps.meta.outputs.tags }}'
+          [ ${#tag_args[@]} -gt 0 ] || { echo "no Docker Hub tags to push"; exit 0; }
+          docker buildx imagetools create "${tag_args[@]}" "${{ steps.ghcr.outputs.source }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [ "main", "beta" ]
     tags: [ 'v*.*.*' ]
+  # beta included: it is a release branch, and a pull request that cannot build
+  # is a change nothing checks until it has already landed there.
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "beta" ]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Reopening #48 with the dual-registry problem fixed. Thanks for the quick revert and for naming the cause in the message — that was the fault, and it was mine.

**What went wrong last time.** The build pushed by digest to both GHCR and Docker Hub. A digest identifies an image inside one registry, and pushing to two produced a different one in each, so the digest the build step reported back was not always the GHCR one. Confirmed on the failing run — the arm64 digest is on Docker Hub and not on GHCR, which is what the merge asked for:

```
docker.io/sonicx161/aiomanager@sha256:bc3bf82f...   FOUND
ghcr.io/sonicx161/aiomanager@sha256:bc3bf82f...     not found
```

**What changed.** Push by digest to GHCR only, assemble the multi-arch manifest there, then copy the finished manifest to Docker Hub with `imagetools create` from the GHCR tag. Both registries end up with the same tags; only the route to Docker Hub differs.

**Also here, and it is why the last one landed untested:** `pull_request` only listed `main`, so a PR targeting `beta` never built. #48 could not be exercised before it merged into a release branch. This adds `beta` to that trigger.

**What this PR does and does not prove.** Both arch builds now run on it and pass. The `merge` job is skipped on pull requests, because there is nothing pushed for it to stitch — so **the step that failed last time is the one CI still cannot reach here.** I would rather say that than let a green tick imply more than it covers.

**Unchanged from #48:** the native matrix. `linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`, so arm64 builds on real hardware rather than under QEMU — around 3.4x on that leg.